### PR TITLE
add nitroshare-desktop

### DIFF
--- a/nitroshare-desktop/linglong.yaml
+++ b/nitroshare-desktop/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.nitroshare-desktop
+  name: github-nitroshare-desktop
+  version: 0.0.1
+  kind: app
+  description: |
+    simple qt nitroshare-desktop.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: icu
+    version: 63.1.0
+    type: runtime
+
+source:
+  kind: git
+  url: "https://github.com/nitroshare/nitroshare-desktop.git"
+  commit: a2fc0eae88fb2ea8a13f02e052a0af47b8532a2f
+
+build:
+  kind: cmake


### PR DESCRIPTION
![A4467970C3179F8B284B0573AD5DDCA8](https://github.com/linuxdeepin/linglong-hub/assets/147463620/3d74b738-2130-4a2e-bac6-f2f340f5a96f)
 上传了一个NitroShare，使文件从一个设备传输到另一个设备极其简单。