### PR TITLE
add upx

### DIFF
--- a/upx/linglong.yaml
+++ b/upx/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: upx
+  name: upx
+  version: 4.1.0
+  kind: lib
+  description: |
+    pack tool.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/upx/upx.git"
+  commit: 2b371e99bd712ba98cf02bf0c433fab82e88c817
+
+build:
+  kind: cmake


### PR DESCRIPTION
详细描述：编译压缩命令行工具upx进玲珑，项目地址：https://github.com/upx/upx.git

Log: 编译完成
![bfb16402e6d5a2bbf5c8b7d8992f3a9](https://github.com/linuxdeepin/linglong-hub/assets/147809353/2a17cd6e-7a49-4517-a2ed-138d0bef3d20)
