### PR TITLE
build: add btop

### DIFF
--- a/io.github.btop/linglong.yaml
+++ b/io.github.btop/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.btop
+  name: github.btop
+  version: 0.0.1
+  kind: app
+  description: |
+    btop for Linux see the system.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/aristocratos/btop.git"
+  commit: 2a864f6f2ea60df16b3f015885eb3c18a48b9b78
+
+build:
+  kind: cmake


### PR DESCRIPTION
Resource monitor that shows usage and stats for processor, memory, disks, network and processes. C++ version and continuation of bashtop and bpytop.

Log: add software name--btop
![0B%${$DYEV`2% @D 4} K~Y](https://github.com/linuxdeepin/linglong-hub/assets/147463620/2aa73ed0-f588-48b6-b606-c1d4eec83a47)
