### PR TITLE
build: add tiny-image-finder                   

### DIFF
--- a/io.github.android-file-transfer-linux/linglong.yaml
+++ b/io.github.android-file-transfer-linux/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.android-file-transfer-linux
+  name: android-file-transfer
+  version: 0.0.1
+  kind: app
+  description: |
+    The MTP's file-transfer by QT.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/whoozle/android-file-transfer-linux.git"
+  commit: a9495bfd712a72011449af6a6d40bc4fc41592e4
+
+build:
+  kind: cmake

--- a/io.github.tiny-image-finder/linglong.yaml
+++ b/io.github.tiny-image-finder/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.tiny-image-finder
+  name: tiny-image-finder
+  version: 0.0.1
+  kind: app
+  description: |
+    Find all images in selected path and show its previews.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/sergey-levin/tiny-image-finder.git"
+  commit: 359870d6be31664a1ed9a65b38151bb8d1fc30cc
+
+build:
+  kind: cmake


### PR DESCRIPTION
finish build tiny-image-finder for ll-builder.

log: 完成tiny-image-finder的编译
![91545686ffbb26ef4a7e0686a3bfd75](https://github.com/linuxdeepin/linglong-hub/assets/101496665/68e65d86-f20f-4289-aa72-4116b01d300e)
