### PR TITLE
build: add flycast

### DIFF
--- a/io.github.flycast/linglong.yaml
+++ b/io.github.flycast/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.flycast
+  name: deepin-flycast
+  version: 2.0.0
+  kind: app
+  description: |
+    simple qt flycast.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/flyinghead/flycast.git"
+  commit: cb9af7d74215a560649def839690d2dd80aae5b0
+
+build:
+  kind: cmake


### PR DESCRIPTION
Detailed description: Migrate and compile Flycast into Linglong, project address: https://github.com/flyinghead/flycast
Log: add app-flycast

![Snipaste_2023-10-17_09-16-53](https://github.com/linuxdeepin/linglong-hub/assets/117267185/61809a88-c7ed-421c-a932-e2e451f7869f)
