### PR TITLE
com.github.lib.libsndfile

### DIFF
--- a/com.github.lib.libsndfile/linglong.yaml
+++ b/com.github.lib.libsndfile/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: libsndfile
+  kind: lib
+  version: 1.2.2
+  description: |
+    upload libsndfile.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/libsndfile/libsndfile.git
+  commit: 7ed4773251c26653b5ee1a0815bfe8b213c14b54
+
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
详细描述：移植、编译依赖libsndfile进玲珑，项目地址：https://github.com/libsndfile/libsndfile.git

Log: 编译完成

![575cd7707717a8e357f082aac2f9959](https://github.com/linuxdeepin/linglong-hub/assets/117267185/a7d7062c-9729-4cc1-aa46-a4a111e9ddab)
