### PR TITLE
add lib io.github.MediaWriter.adwaita-qt

### DIFF
--- a/com.github.lib.adwaita-qt/linglong.yaml
+++ b/com.github.lib.adwaita-qt/linglong.yaml
@@ -2,7 +2,7 @@ package:
   id: io.github.MediaWriter.adwaita-qt
   name: adwaita-qt
   version: 1.4.2
-  kind: app
+  kind: lib
   description: |
     adwaita-qt.
 
@@ -10,18 +10,11 @@ runtime:
   id: org.deepin.Runtime
   version: 23.0.0
 
-depends:
-  - id: icu
-    version: 63.1.0
-    type: runtime
-
-
 source:
   kind: git
   url: https://github.com/FedoraQt/adwaita-qt.git
   version: master
   commit: 0a774368916def5c9889de50f3323dec11de781e
-
 
 build:
   kind: cmake

--- a/com.github.lib.adwaita-qt/linglong.yaml
+++ b/com.github.lib.adwaita-qt/linglong.yaml
@@ -1,0 +1,42 @@
+package:
+  id: com.github.lib.adwaita-qt
+  name: adwaita-qt
+  version: 1.4.2
+  kind: app
+  description: |
+    adwaita-qt.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: icu
+    version: 63.1.0
+    type: runtime
+
+
+source:
+  kind: git
+  url: https://github.com/FedoraQt/adwaita-qt.git
+  version: master
+  commit: 0a774368916def5c9889de50f3323dec11de781e
+
+
+build:
+  kind: cmake
+  manual:
+    configure: |
+      mkdir build && cd build
+    build: |
+      cmake ..
+      make
+    install: |
+      make install
+
+
+
+
+
+
+

--- a/com.github.lib.adwaita-qt/linglong.yaml
+++ b/com.github.lib.adwaita-qt/linglong.yaml
@@ -1,5 +1,5 @@
 package:
-  id: com.github.lib.adwaita-qt
+  id: io.github.MediaWriter.adwaita-qt
   name: adwaita-qt
   version: 1.4.2
   kind: app
@@ -25,18 +25,3 @@ source:
 
 build:
   kind: cmake
-  manual:
-    configure: |
-      mkdir build && cd build
-    build: |
-      cmake ..
-      make
-    install: |
-      make install
-
-
-
-
-
-
-

--- a/com.github.lib.adwaita-qt/linglong.yaml
+++ b/com.github.lib.adwaita-qt/linglong.yaml
@@ -1,10 +1,10 @@
 package:
-  id: io.github.MediaWriter.adwaita-qt
+  id: adwaita-qt
   name: adwaita-qt
   version: 1.4.2
   kind: lib
   description: |
-    adwaita-qt.
+    A native style to bend Qt5/Qt6 applications to look like they belong into GNOME Shell. This style provides all four variants of GTK Adwaita theme.
 
 runtime:
   id: org.deepin.Runtime


### PR DESCRIPTION
一个lib依赖库，实现MediaWriter的构建工作。

git地址：https://github.com/FedoraQt/adwaita-qt

![2a66ba7abfa087f8ccc8c99d0181172b](https://github.com/linuxdeepin/linglong-hub/assets/115330610/82b961a8-23a5-4720-b7b2-b2437d162a3b)
