### PR TITLE
build lib:libsndfile

### DIFF
--- a/libsndfile/linglong.yaml
+++ b/libsndfile/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: libsndfile
+  name: libsndfile
+  kind: lib
+  version: 1.2.2
+  description: |
+    A C library for reading and writing sound files containing sampled audio data.
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/libsndfile/libsndfile.git
+  commit: 7ed4773251c26653b5ee1a0815bfe8b213c14b54
+
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
build lib:libsndfile 
Finish build lib:libsndfile for ll-builder
lib address : https://github.com/libsndfile/libsndfile.git
![575cd7707717a8e357f082aac2f9959](https://github.com/linuxdeepin/linglong-hub/assets/117267185/dbd76f9e-58c8-4c70-9eae-4ea70450772d)
Complete the compilation of libsndfile