### PR TITLE
add pkgconf

### DIFF
--- a/pkgconf/linglong.yaml
+++ b/pkgconf/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: pkgconf
+  name: pkgconf
+  version: 2.0.3
+  kind: lib
+  description: |
+    package compiler and linker metadata toolkit.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+depends:
+  - id: automake/1.16.5
+  - id: libtool/2.4.2
+
+source:
+  kind: git
+  url: https://github.com/pkgconf/pkgconf.git
+  commit: a6fb59a0ed86cfe302a2916cf93e9b032b95c8c5
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./autogen.sh
+      ./configure ${conf_args} ${extra_args}


### PR DESCRIPTION
编译成功：
![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/3ac637ef-67e3-4fc2-8bd7-00b1d1a40aa9)


package compiler and linker metadata toolkit.

Log: add lib name--pkgconf