### PR TITLE
build: add cmake 3.28

### DIFF
--- a/cmake/linglong.yaml
+++ b/cmake/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: cmake
+  name: cmake
+  version: 3.28.0
+  kind: lib
+  description: |
+    latest version cmake.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/Kitware/CMake.git"
+  commit: d3bcbdc5a2a1c5402c742eaa73089b1645856a5b
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
某些项目需要3.26以上版本cmake.

Log: 更新了3.28的cmake
![image](https://github.com/linuxdeepin/linglong-hub/assets/147809353/bcaa7e9c-30b9-4ff2-a55f-b6ab5fb60781)
