### PR TITLE
build: add libgit2

### DIFF
--- a/libgit2/linglong.yaml
+++ b/libgit2/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: libgit2
+  name: libgit2
+  version: 1.7.1
+  kind: lib
+  description: |
+    libgit2 is a portable, pure C implementation of the Git core methods provided as a linkable library with a solid API, allowing to build Git functionality into your application. Language bindings like Rugged (Ruby), LibGit2Sharp (.NET), pygit2 (Python) and NodeGit (Node) allow you to build Git tooling in your favorite language.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/libgit2/libgit2.git"
+  commit: a6205fa5c1f856b9a7b3908077aa935a1b82fed9
+
+build:
+  kind: cmake


### PR DESCRIPTION
finish build libgit2 lib for ll-builder.

log: 完成libgit2 的编译,libgit2是gitg所必须的依赖
![image](https://github.com/linuxdeepin/linglong-hub/assets/51472974/171de95a-ebe6-4e40-a188-4d63999974d9)
