### PR TITLE
build: add qjackctl

### DIFF
--- a/io.github.qjackctl/linglong.yaml
+++ b/io.github.qjackctl/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qjackctl
+  name: github.qjackctl
+  version: 0.0.1
+  kind: app
+  description: |
+    qjackctl a simple Qt application to control the JACK sound server
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/rncbc/qjackctl.git"
+  commit: 55bcc161b27d7363a08e0822b104390764f86963
+
+build:
+  kind: cmake


### PR DESCRIPTION

![I`4E }E~NE0YD9RVFZ6$XYA](https://github.com/linuxdeepin/linglong-hub/assets/147463620/f6ead141-1d9d-4360-9b2b-41e37c88b80f)
Provides a simple GUI dialog for setting several JACK server parameters, which are properly saved between sessions, and a way control of the status of the audio server. With time, this primordial interface has become richer by including a enhanced patchbay and connection control features.

Log: add software name--qjackctl