### PR TITLE
build: add automake1.11

### DIFF
--- a/automake1.11/linglong.yaml
+++ b/automake1.11/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: automake1.11
+  name: automake1.11
+  version: 1.11.0.1
+  kind: lib
+  description: |
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/deepin-community/automake1.11.git"
+  commit: fbb5a0607dce387bb3d5c9f786f355a6dc022aab
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./bootstrap
+      ./configure ${conf_args} 
+      


### PR DESCRIPTION
![截图_deepin-terminal_20231018131643](https://github.com/linuxdeepin/linglong-hub/assets/84424520/25802dcf-13ca-4ae8-ad24-e2817a5d1890)
库中automake版本为1.16,pipewalker依赖于automake1.11