### PR TITLE
build: add adwaita-qt

### DIFF
--- a/adwaita-qt/linglong.yaml
+++ b/adwaita-qt/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: adwaita-qt
+  name: adwaita-qt
+  version: 1.4.2
+  kind: lib
+  description: |
+    A native style to bend Qt5/Qt6 applications to look like they belong into GNOME Shell.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/FedoraQt/adwaita-qt.git
+  commit: 0a774368916def5c9889de50f3323dec11de781e
+
+
+build:
+  kind: cmake
+
+
+
+
+
+
+


### PR DESCRIPTION
build lib: adwaita-qt, adwaita-qt for ll-builder
![48d889aa-9589-484a-b912-fa66a44b2ac1](https://github.com/linuxdeepin/linglong-hub/assets/115330610/6ba0858f-91f4-46f7-9a2c-feaa641839e7)
Log: 完成对adwaita-qt的编译。
