### PR TITLE
build:nvidia-system-monitor

### DIFF
--- a/nvidia-system-monitor-qt/linglong.yaml
+++ b/nvidia-system-monitor-qt/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: org.nvidia.qt
+  name: nvidia.qt
+  version: 0.0.1
+  kind: app
+  description: |
+    nvidia.qt
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: icu
+    version: 63.1.0
+    type: runtime
+
+source:
+  kind: git
+  url: "https://github.com/congard/nvidia-system-monitor-qt"
+  commit: 66d9895f520d7ecc8de4c3408340890fbb7b2126
+
+build:
+  kind: manual
+  manual:
+    configure: |
+      mkdir build
+    build: |
+      cmake -DCMAKE_BUILD_TYPE=Release -DIconPath=/usr/share/icons/hicolor/512x512/apps/nvidia-system-monitor-qt.png -B build -G "Unix Makefiles"
+    install: |
+      cmake --build build --target qnvsm -- -j 4
+      cp build/qnvsm /opt/apps/org.nvidia.qt/files/bin/ 


### PR DESCRIPTION
build:nvidia-system-monitor
Finish build tnvidia-system-monitor for ll-builder.

Log:完成对nvidia-system-monitor的编译
![image](https://github.com/linuxdeepin/linglong-hub/assets/28189124/34458cb8-2a3a-4d9a-9873-402ddaba2deb)
