### PR TITLE
build: add qtKeychain

### DIFF
--- a/qtkeychain/linglong.yaml
+++ b/qtkeychain/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: qtkeychain
+  name: qtkeychain
+  version: 0.14.0
+  kind: lib
+  description: |
+    QtKeychain is a Qt API to store passwords and other secret data securely.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/frankosterfeld/qtkeychain.git
+  commit: 01a900bad178f69fcb0f9bc4b067c37d97762aa2
+
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
build lib: qtKeychain, qtKeychain for desktop app
git url: https://github.com/frankosterfeld/qtkeychain

![7da63ff045dd8db80a02145736473a2a](https://github.com/linuxdeepin/linglong-hub/assets/115330610/42b3ad83-7c1f-45a2-b45c-1ee71be15761)

Log: finish lib qtKeychain