### PR TITLE
build:qtrvsim

### DIFF
--- a/io.github.cvut.qtrvsim/linglong.yaml
+++ b/io.github.cvut.qtrvsim/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.cvut.qtrvsim
+  name: qtrvsim
+  version: 0.9.5
+  kind: app
+  description: |
+    RISC-V CPU simulator for education purposes
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+source:
+  kind: git
+  url: "https://github.com/cvut/qtrvsim.git"
+  commit: ea0a68eb0fde014839a31a0430527e1755b76458
+build:
+  kind: manual
+  manual:
+    configure: |
+      cmake -DCMAKE_BUILD_TYPE=Release 
+    install: |
+      make


### PR DESCRIPTION
build:qtrvsim
Finish build:qtrvsim for ll-builder.

Log:完成对qtrvsim的编译和运行
![9110514dd6c6554f3d2a5ac4450c74d](https://github.com/linuxdeepin/linglong-hub/assets/28189124/23477bb6-cfd6-4831-8779-cdac14f27bc9)
