### PR TITLE
build: add apk-editor-studio

### DIFF
--- a/io.github.apk-editor-studio/linglong.yaml
+++ b/io.github.apk-editor-studio/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.apk-editor-studio
+  name: apk-editor-studio
+  version: 1.8.0
+  kind: app
+  description: |
+     powerful yet easy to use APK reverse-engineering tool
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/kefir500/apk-editor-studio.git"
+  commit: 59eb47df6b83d956a2047c2d1da863dcf09b8fb9
+
+build:
+  kind: cmake


### PR DESCRIPTION
APK Editor Studio is a powerful yet easy to use APK reverse-engineering tool

Log: add software name--apk-editor-studio
![apk-editor-studio](https://github.com/linuxdeepin/linglong-hub/assets/147463620/64bb5488-4937-4dc4-a1ec-24d94d48bfe8)
