### PR TITLE
build: add snomcontrol

### DIFF
--- a/io.github.snomcontrol/linglong.yaml
+++ b/io.github.snomcontrol/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.snomcontrol
+  name: snomcontrol
+  version: 3.0.0
+  kind: app
+  description: |
+    An application to control snom (D)3xx phones from the desktop
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine
+    version: 5.15.7
+
+source:
+  kind: git
+  url: "https://github.com/ballessay/snomcontrol.git"
+  commit: fb27615081890ae88a394fb169957779d950f0f1
+
+build:
+  kind: cmake


### PR DESCRIPTION

![snomcontrol](https://github.com/linuxdeepin/linglong-hub/assets/147463620/c9b34fff-2f57-47a2-b8e9-7c76ee8e54ef)
An application to control snom (D)3xx phones from the desktop

Log: add software name--snomcontrol