### PR TITLE
build: add gpupad

### DIFF
--- a/io.github.gpupad/linglong.yaml
+++ b/io.github.gpupad/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.gpupad
+  name: gpupad
+  version: 1.35.0
+  kind: app
+  description: |
+    A lightweight editor for GLSL shaders of all kinds and a fully-featured IDE for developing GPU based algorithms.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/houmain/gpupad.git"
+  commit: b843165298f70671366a2db580c7ae0ec9a316c8
+
+build:
+  kind: cmake


### PR DESCRIPTION

![gpupad](https://github.com/linuxdeepin/linglong-hub/assets/147463620/0e881654-bfa6-41f6-83b8-0bc7105c2b6e)
A lightweight editor for GLSL shaders of all kinds and a fully-featured IDE for developing GPU based algorithms.

Log: add software name--gpupad