### PR TITLE
build: add libgif7

### DIFF
--- a/libgif7/linglong.yaml
+++ b/libgif7/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: libgif7
+  name: libgif7
+  version: 5.1.9.0
+  kind: lib
+  description: |
+    library for GIF images.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://git.code.sf.net/p/giflib/code.git
+  commit: 866ea0643315db2d985e9ec4b1707a4f4ca404f0
+  patch:
+    - patches/disable-doc-patch.patch
+    - patches/fix-install-var-patch.patch
+
+build:
+    kind: autotools
+    manual:
+      configure: |
+      build: |
+        make ${jobs} CC=gcc
+      install: |
+        make ${jobs} DESTDIR=${dest_dir} PREFIX=${PREFIX} LIBDIR=${PREFIX}/lib/${TRIPLET} install

--- a/libgif7/patches/disable-doc-patch.patch
+++ b/libgif7/patches/disable-doc-patch.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile b/Makefile
+index e4ded69..9c344a4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -63,7 +63,7 @@ UTILS = $(INSTALLABLE) \
+ LDLIBS=libgif.a -lm
+ 
+ all: libgif.so libgif.a libutil.so libutil.a $(UTILS)
+-	$(MAKE) -C doc
++#	$(MAKE) -C doc
+ 
+ $(UTILS):: libgif.a libutil.a
+ 
+@@ -105,7 +105,7 @@ install-lib:
+ 	ln -sf libgif.so.$(LIBMAJOR) "$(DESTDIR)$(LIBDIR)/libgif.so"
+ install-man:
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
+-	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
++#	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
+ uninstall: uninstall-man uninstall-include uninstall-lib uninstall-bin
+ uninstall-bin:
+ 	cd "$(DESTDIR)$(BINDIR)" && rm -f $(INSTALLABLE)

--- a/libgif7/patches/fix-install-var-patch.patch
+++ b/libgif7/patches/fix-install-var-patch.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile b/Makefile
+index e4ded69..2fad940 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,11 +14,11 @@ SHELL = /bin/sh
+ TAR = tar
+ INSTALL = install
+ 
+-PREFIX = /usr/local
+-BINDIR = $(PREFIX)/bin
+-INCDIR = $(PREFIX)/include
+-LIBDIR = $(PREFIX)/lib
+-MANDIR = $(PREFIX)/share/man
++PREFIX ?= /usr/local
++BINDIR ?= $(PREFIX)/bin
++INCDIR ?= $(PREFIX)/include
++LIBDIR ?= $(PREFIX)/lib
++MANDIR ?= $(PREFIX)/share/man
+ 
+ # No user-serviceable parts below this line


### PR DESCRIPTION
![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/de06877b-0ea8-4b34-9928-d00bd3fc501e)
编译成功

因为源码里没有 `configure` 之类的文件，只有 `Makefile` 文件，其中 `PREFIX` 和 `LIBDIR` 是写死的，而且编译生成文档时会会下载文件，需要代理，所以使用补丁统一进行修改。

[https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=giflib-git](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=giflib-git)

library for GIF images.

Log: add lib name--libgif7