### PR TITLE
build: add qtsconverter

### DIFF
--- a/io.github.qtsconverter/linglong.yaml
+++ b/io.github.qtsconverter/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qtsconverter
+  name: qtsconverter
+  version: 4.4.0
+  kind: app
+  description: |
+    A simple tool to convert qt translation file (ts) to other format (xlsx / csv) and vice versa.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/guerinoni/qTsConverter.git"
+  commit: 60190f8b5558496b79f8d1909c6e5d8ee5bc21bc
+
+build:
+  kind: cmake


### PR DESCRIPTION
A simple tool to convert qt translation file (ts) to other format (xlsx / csv) and vice versa.

log: add app --qtsconverter

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/56b9a562-5d15-4d3b-9861-4346c38a7d69)
