### PR TITLE
build: add Nanonote

### DIFF
--- a/io.github.Nanonote/linglong.yaml
+++ b/io.github.Nanonote/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.Nanonote
+  name: Nanonote
+  version: 1.4.0
+  kind: app
+  description: |
+    Nanonote is a minimalist note taking application.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/agateau/nanonote.git"
+  commit: 5ccf2f846004f442ef82a450573a389d4f9f6ea7
+
+build:
+  kind: cmake


### PR DESCRIPTION
Nanonote is a minimalist note taking application.

log: add app--Nanonote

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/2f0176ab-b9e8-4c34-9124-297e025d6aed)
