### PR TITLE
build: add portaudio

### DIFF
--- a/portaudio/linglong.yaml
+++ b/portaudio/linglong.yaml
@@ -1,0 +1,18 @@
+package:
+  id: portaudio
+  name: portaudio
+  version: 19.7.0
+  kind: lib
+  description: |
+    PortAudio is a cross-platform, open-source C language library for real-time audio input and output.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/PortAudio/portaudio.git
+  commit: 24c8d575e588d557d28f4011becb753421346860
+build:
+  kind: cmake


### PR DESCRIPTION
PortAudio is a cross-platform, open-source C language library for real-time audio input and output.

log: add lib--PortAudio 
![image-20231020180340940](https://github.com/linuxdeepin/linglong-hub/assets/117267185/5831bc24-709e-45cd-bd52-bd1b8b2efaea)
