### PR TITLE
build: add lib wxWidgets

### DIFF
--- a/wxWidgets/linglong.yaml
+++ b/wxWidgets/linglong.yaml
@@ -1,0 +1,35 @@
+package:
+  id: wxWidgets
+  name: wxWidgets
+  version: 3.2.3
+  kind: lib
+  description: |
+    wxWidgets is a free and open source cross-platform C++ framework for writing advanced GUI applications using native controls.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: automake
+    version: 1.16.5
+
+source:
+  kind: git
+  url: https://github.com/especiallyW/wxWidgets.git
+  commit: 577113e7e2fc62b10222483574ebf7183a8c66bc
+
+
+variables:
+  conf_args: |
+    --prefix=${PREFIX} \
+    --libdir=${PREFIX}/lib/${TRIPLET}
+  extra_args: |
+    --with-gtk
+
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./configure ${conf_args} ${extra_args}


### PR DESCRIPTION
实现应用treesheets时，缺少wxwidgets依赖包，此版本为3.2.3.

![6d2227e6-137f-4220-85bc-58f954721990](https://github.com/linuxdeepin/linglong-hub/assets/115330610/d3d313e9-efbb-4b9f-af88-d2e9be7e75cb)

Log：finish lib build.