### PR TITLE
build: add laigter

### DIFF
--- a/io.github.laigter/linglong.yaml
+++ b/io.github.laigter/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.laigter
+  name: laigter
+  version: 1.11.0
+  kind: app
+  description: |
+    a tool that automatically generates maps for dynamic lighting effects in games. It allows normal, parallax, specular and occlusion map generation. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/azagaya/laigter.git"
+  commit: ca753108144903ed37c3dcc370d33ae5f7b34152
+
+build:
+  kind: qmake


### PR DESCRIPTION
Laigter is a tool that automatically generates maps for dynamic lighting effects in games. it allows normal, parallax, specular and occlusion map generation.

Log: add software name--laigter
![laigter](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9f2243bd-c041-4801-9f5d-d4a600b43914)
