### PR TITLE
build: add flameshot

### DIFF
--- a/io.github.flameshot/linglong.yaml
+++ b/io.github.flameshot/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.flameshot
+  name: flameshot
+  version: 12.1.0
+  kind: app
+  description: |
+    Powerful yet simple to use screenshot software.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/flameshot-org/flameshot.git
+  commit: 70be63d478a271da549597d69bd4868607c0a395
+
+
+build:
+  kind: cmake


### PR DESCRIPTION
flameshot, 一款截图标注工具。

git地址: https://github.com/flameshot-org/flameshot/tree/v12.1.0

![5c6815cdb0d80dcec6befd3b1b1abaa0](https://github.com/linuxdeepin/linglong-hub/assets/115330610/1890b1a6-ec34-450b-88c4-df669f22ce17)

Log: finish app flameshot.