### PR TITLE
build: add lib lxqt-build-tools

### DIFF
--- a/lxqt-build-tools/linglong.yaml
+++ b/lxqt-build-tools/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: lxqt-build-tools
+  name: lxqt-build-tools
+  version: 0.13.0
+  kind: lib
+  description: |
+    Various packaging tools and scripts for LXQt applications.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/lxqt/lxqt-build-tools.git
+  commit: 1304079edbe62c8c9e528de8ee0cf1a1119724dc
+
+
+build:
+  kind: cmake


### PR DESCRIPTION
一个lib依赖库，依赖库libfm-qt依赖此依赖开发。

![970d9099-2974-4c2c-a896-4a4a8be615a9](https://github.com/linuxdeepin/linglong-hub/assets/115330610/520ee60b-bbc4-4d63-bfc3-8ba5f7cdfe79)

Log: finish lib lxqt-build-tools.