### PR TITLE
build: add app MediaWriter

### DIFF
--- a/io.github.MediaWriter/linglong.yaml
+++ b/io.github.MediaWriter/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.MediaWriter
+  name: MediaWriter
+  version: 4.2.2
+  kind: app
+  description: |
+    Fedora Media Writer is a tool that helps users put Fedora images on their portable drives such as flash disks.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: adwaita-qt
+    version: 1.4.2
+    type: runtime
+
+
+source:
+  kind: git
+  url: https://github.com/FedoraQt/MediaWriter.git
+  commit: 2b9acbd94e9c2c93cd79fbbc692eed2b672ca010
+
+build:
+  kind: cmake
+
+
+
+
+
+
+


### PR DESCRIPTION
Fedora Media Writer是一个工具，可以帮助用户将Fedora图像放在他们的便携式驱动器上，如闪存盘。

![90cd746e4ce7489701118f229ba06384](https://github.com/linuxdeepin/linglong-hub/assets/115330610/2678a417-b2a4-4aec-b07c-aadd93a90059)

Log: finish make MediaWriter.