### PR TITLE
build: add lib fltk

### DIFF
--- a/fltk/linglong.yaml
+++ b/fltk/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: fltk
+  name: fltk
+  version: 1.4.0
+  kind: lib
+  description: |
+    The Fast Light Tool Kit ("FLTK", pronounced "fulltick") is a cross-platform C++ GUI toolkit for UNIX(r)/Linux(r) (X11), Microsoft(r) Windows(r), and MacOS(r) X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL(r) and its built-in GLUT emulation. It was originally developed by Mr. Bill Spitzak and is currently maintained by a small group of developers across the world with a central repository in the US.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/fltk/fltk.git
+  commit: 17baeceb7ab90251f99c7909eb9eeca92aec5a05
+
+
+build:
+  kind: cmake


### PR DESCRIPTION
fltk是polished-map应用的依赖包。

git地址：https://github.com/fltk/fltk/tree/release-1.3.7。

![ca8e0030-e6d6-4354-883b-1eb06f587e79](https://github.com/linuxdeepin/linglong-hub/assets/115330610/d3bb127e-1a57-4514-97de-bddc85fc6524)

Log: finish lib fltk.

