### PR TITLE
build : add lib itstool

### DIFF
--- a/itstool/linglong.yaml
+++ b/itstool/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: itstool
+  name: itstool
+  version: 0.0.1
+  kind: lib
+  description: |
+    pack tool.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/deepin-community/itstool.git"
+  commit: 9a9ab8e7386ab46c758bcd1bb5f76b867c23670e
+
+build:
+  kind: Makefile


### PR DESCRIPTION
itstool是应用pentobi的依赖

git地址：https://github.com/deepin-community/itstool.git

![1697877132221](https://github.com/linuxdeepin/linglong-hub/assets/78958771/fbc2a262-39ef-4690-9a96-59213cf453b0)

Log: finish lib itstool.
