### PR TITLE
build: add lib texinfo

### DIFF
--- a/texinfo/linglong.yaml
+++ b/texinfo/linglong.yaml
@@ -1,0 +1,31 @@
+package:
+  id: texinfo
+  name: texinfo
+  version: 6.8
+  kind: lib
+  description: |
+    lib texinfo.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: archive
+  url: https://ftp.gnu.org/gnu/texinfo/texinfo-6.8.tar.xz
+  digest: 8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4
+
+
+build:
+  kind: manual
+  manual:
+    configure: |
+      cd texinfo-6.8
+      ./configure
+    build: |
+      make
+    install: |
+      make install
+


### PR DESCRIPTION
libcdio需要此依赖包作为支撑，此包版本为6.8.

![c28809ff-b800-4757-b902-e8b12a38e0e7](https://github.com/linuxdeepin/linglong-hub/assets/115330610/6d607eed-3b87-4c59-b8c6-276bacbde91b)

Log: finish lib texinfo.