### PR TITLE
build: lib crengine_ng

### DIFF
--- a/crengine-ng/linglong.yaml
+++ b/crengine-ng/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: crengine-ng
+  name: crengine-ng
+  version: 0.9.10
+  kind: lib
+  description: |
+    crengine-ng is cross-platform library designed to implement text and e-book readers
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: zlib
+    version: 1.2.12.4
+    type: runtime
+source:
+  kind: git
+  url: https://gitlab.com/coolreader-ng/crengine-ng.git  
+  commit: 460124f7d46373c7b9f9aa981938ffa6e3396f75
+build:
+  kind: cmake


### PR DESCRIPTION
build: lib crengine_ng

![N$H}6XPHYD)6KH5GKBVJU@M](https://github.com/linuxdeepin/linglong-hub/assets/28189124/1002cc03-0f58-4be9-851e-d0f57f22c09f)

Logs:success build lib crengine_ng for coolreader-ng