### PR TITLE
build: add sqlitebrowser

### DIFF
--- a/io.github.sqlitebrowser/linglong.yaml
+++ b/io.github.sqlitebrowser/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.sqlitebrowser
+  name: sqlitebrowser
+  version: 3.12.2
+  kind: app
+  description: |
+    a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/sqlitebrowser/sqlitebrowser.git"
+  commit: 00a5e2ebe937af4d46a8b51b67fc7eba4950f2be
+
+build:
+  kind: cmake


### PR DESCRIPTION

![sqlitebrowser](https://github.com/linuxdeepin/linglong-hub/assets/147463620/f9b684ec-ee3f-4b42-a236-bbcb1d976f79)
DB4S is for users and developers who want to create, search, and edit databases. DB4S uses a familiar spreadsheet-like interface, so complicated SQL commands do not have to be learned.

Log: add software name--sqlitebrowser