### PR TITLE
build: add Flips

### DIFF
--- a/io.github.Flips/linglong.yaml
+++ b/io.github.Flips/linglong.yaml
@@ -1,0 +1,29 @@
+package:
+  id: io.github.Flips
+  name: Flips
+  version: 1.31.0
+  kind: app
+  description: |
+    Floating IPS is a patcher for IPS and BPS files.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/Alcaro/Flips.git
+  commit: fdd5c6e34285beef5b9be759c9b91390df486c66
+
+
+build:
+  kind: manual
+  manual:
+    configure: |
+      ./make.sh
+    build: |
+      make
+    install: |
+      make install
+


### PR DESCRIPTION
Flips: Floating IPS is a patcher for IPS and BPS files.

![6e8408034546899dcf71c2af07004bdf](https://github.com/linuxdeepin/linglong-hub/assets/115330610/2652a371-2109-42ed-b633-1978645f129e)

Log: finish app Flips.