### PR TITLE
build: add ColorPicker

### DIFF
--- a/KolcorPicker/linglong.yaml
+++ b/KolcorPicker/linglong.yaml
@@ -1,0 +1,29 @@
+package:
+  id: io.github.ColorPicker
+  name: ColorPicker
+  version: 1.0.3
+  kind: app
+  description: |
+    ColorPicker is a powerful screen color picker based on Qt's QColorDialog Class.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+  
+source:
+  kind: git
+  url: "https://github.com/keshavbhatt/ColorPicker.git"
+  commit: 34594350d9c60ea6f96db07694a5ed2e84673f46
+
+build:
+  kind: qmake 
+  manual:
+    configure: |
+      qmake src/  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install
+
+    
+    


### PR DESCRIPTION
![截图_选择区域_20231023151441](https://github.com/linuxdeepin/linglong-hub/assets/84424520/1dbaa943-5e50-4f69-9912-2b8e3848995f)

ColorPicker is a powerful screen color picker based on Qt's QColorDialog Class.
