### PR TITLE
build: add Cutepeaks

### DIFF
--- a/io.github.Cutepeaks/linglong.yaml
+++ b/io.github.Cutepeaks/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.CutePeaks
+  name: CutePeaks
+  version: 0.2.3
+  kind: app
+  description: |
+    It has regular expression pattern finder and can export trace as SVG vector image.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/labsquare/CutePeaks.git"
+  commit: c3717fcce7bcf9bc397e3a548ea2a9db227ae0f9
+
+build:
+  kind: qmake


### PR DESCRIPTION

![CutePeaks](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ec095088-2793-4e09-856a-535f0af21ee7)
Supports AB1 and SCF 3.0 file formats. It has regular expression pattern finder and can export trace as SVG vector image.

Log: add software name--Cutepeaks