### PR TITLE
build: add whatsie

### DIFF
--- a/io.github.whatsie/linglong.yaml
+++ b/io.github.whatsie/linglong.yaml
@@ -1,0 +1,33 @@
+package:
+  id: io.github.whatsie
+  name: whatsie
+  version: 4.14.1
+  kind: app
+  description: |
+     Feature rich WhatsApp web client based on Qt WebEngine for Linux Desktop
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+  
+source:
+  kind: git
+  url: "https://github.com/keshavbhatt/whatsie.git"
+  commit: 906ca7eb436dc9944d43f5b7f6ae7b44afc2a3e7
+
+depends:
+  - id: qtwebengine/5.15.7
+
+build:
+  kind: qmake 
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install
+
+    
+    


### PR DESCRIPTION
![image](https://github.com/linuxdeepin/linglong-hub/assets/84424520/7daf9a50-d7c8-4d6f-b257-e2a6064f7202)
Feature rich WhatsApp web client based on Qt WebEngine for Linux Desktop

似乎这个app要联外网？容器内run之后没内容加载诶