### PR TITLE
build: add lib qtscxml

### DIFF
--- a/qtscxml/linglong.yaml
+++ b/qtscxml/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: qtscxml
+  name: qtscxml
+  version: 5.15.7
+  kind: lib
+  description: |
+    SCXML (state machine notation) compiler and related tools.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/qt/qtscxml.git
+  commit: e1faea1db52b91d90ef64dd57eb6529e323b5526
+
+build:
+  kind: qmake


### PR DESCRIPTION
一个应用需要使用qt5的子模块scxml,而该子模块不存在。

![99082244-4db9-47ab-a078-0f7c9ce45cc8](https://github.com/linuxdeepin/linglong-hub/assets/115330610/a87e307e-3b5b-41eb-9030-9233ff969139)

Log: finish lib qtscxml.