### PR TITLE
build: add NotepadNext

### DIFF
--- a/io.github.NotepadNext/linglong.yaml
+++ b/io.github.NotepadNext/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.NotepadNext
+  name: NotepadNext
+  version: 0.6.4
+  kind: app
+  description: |
+    Notepad Next is yet another text and source code editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/dail8859/NotepadNext.git"
+  commit: ccbd3484862ec1f833af428a8050260fd1511566
+
+variables:
+  extra_args: |
+     src
+
+build:
+  kind: qmake


### PR DESCRIPTION
  Notepad Next is yet another text and source code editor.

log: add app--NotepadNext

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/bf1d538a-b87b-4a40-b65e-8e2d2b2bfab8)
