### PR TITLE
build: add qmidictl

### DIFF
--- a/io.github.qmidictl/linglong.yaml
+++ b/io.github.qmidictl/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.qmidictl
+  name: qmidictl
+  version: 0.9.12
+  kind: app
+  description: |
+    QmidiCtl is a MIDI remote controller application that sends MIDI data ver the network, using UDP/IP multicast.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/rncbc/qmidictl.git
+  commit: 441acc70c37a0596c353e6fb0a9709f9cfb68c77
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
一款小工具，QmidiCtl是一个发送MIDI数据的MIDI远程控制器应用程序，通过网络，使用 UDP/IP 多播。

![0791e1cc-7dfb-4877-bca8-cc2d3e461753](https://github.com/linuxdeepin/linglong-hub/assets/115330610/44c73d26-48bb-49c9-bc9f-afa48502934e)

Log: finish qmidictl