### PR TITLE
build: add rpan-studio

### DIFF
--- a/io.github.rpan-studio/linglong.yaml
+++ b/io.github.rpan-studio/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.rpan-studio
+  name: rpan-studio
+  version: 26.0.2
+  kind: app
+  description: |
+   this is a software designed for capturing, compositing, encoding, recording, and streaming video content, efficiently.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/reddit/rpan-studio.git"
+  commit: a54dfe7deb2b23303a4f1f3a0559a7a8c36bca56
+
+build:
+  kind: cmake


### PR DESCRIPTION

![rpan-studio](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b28bbe14-2aa5-4e15-81a9-2546de5cbef3)
A software designed for capturing, compositing, encoding, recording, and streaming video content, efficiently.

Log: add software name--rpan-studio