### PR TITLE
build: add Fractale

### DIFF
--- a/io.github.Fractale/linglong.yaml
+++ b/io.github.Fractale/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.Fractale
+  name: Fractale
+  version: 1.5.1
+  kind: app
+  description: |
+    Two-dimensional simulation of Von Koch fractal and its variation
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/PJK136/Fractale.git"
+  commit: cadfc6efefb461a7e6e9b21d8702aba3860341fc
+
+build:
+  kind: qmake


### PR DESCRIPTION

![Fractale](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e3cc65e2-790a-448b-bac6-77e06b0c149e)
Modélisation 2D de la fractale de Von Koch avec différentes variantes.

Log: add software name--Fractale