### PR TITLE
build: add qucs_s

### DIFF
--- a/io.github.qucs_s/linglong.yaml
+++ b/io.github.qucs_s/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qucs_s
+  name: qucs_s
+  version: 2.0.0
+  kind: app
+  description: |
+    provides a fancy graphical user interface for a number of popular circuit simulation engines
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/ra3xdh/qucs_s.git"
+  commit: 846ec630c7085498da3f208c94af1c3cffd7c236
+
+build:
+  kind: cmake


### PR DESCRIPTION
provides a fancy graphical user interface for a number of popular circuit simulation engines.

Log: add software name--qucs_s
![qucs_s](https://github.com/linuxdeepin/linglong-hub/assets/147463620/2ac303ab-bcc7-42f6-93be-8c4949887475)
