### PR TITLE
build: add Heimer

### DIFF
--- a/io.github.Heimer/linglong.yaml
+++ b/io.github.Heimer/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.Heimer
+  name: Hermer
+  version: 4.2.0
+  kind: app
+  description: |
+    a desktop application for creating mind maps and other suitable diagrams.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/juzzlin/Heimer.git"
+  commit: b4eba269fb31abb0e447b62bee54ecaa79301024
+
+build:
+  kind: cmake


### PR DESCRIPTION

![Heimer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/51cff8a3-fd62-4841-9162-64fd4e18874a)
a desktop application for creating mind maps and other suitable diagrams. It's written in Qt and targeted for Linux and Windows.

Log: add software name--Heimer