### PR TITLE
build: add lib fluidsynth

### DIFF
--- a/fluidsynth/linglong.yaml
+++ b/fluidsynth/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: fluidsynth
+  name: fluidsynth
+  version: 2.3.4
+  kind: lib
+  description: |
+    FluidSynth is a cross-platform, real-time software synthesizer based on the Soundfont 2 specification.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/FluidSynth/fluidsynth.git
+  commit: 377ab9db2f87bc407eeb940e0361edc77da77055
+
+build:
+  kind: cmake
+
+
+
+


### PR DESCRIPTION
一个依赖库，后续的qsynth应用需要使用。

![ea211363299143d9ccf0d3134cb2f407](https://github.com/linuxdeepin/linglong-hub/assets/115330610/1c52bc01-c5a8-485b-89cb-1bcb8d990188)

Log: finish lib fluidsynth.