### PR TITLE
build: add qsynth

### DIFF
--- a/io.github.qsynth/linglong.yaml
+++ b/io.github.qsynth/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.qsynth
+  name: qsynth
+  version: 0.9.13
+  kind: app
+  description: |
+    Qsynth is a fluidsynth GUI front-end application written in C++ around the Qt framework using Qt Designer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: fluidsynth
+    version: 2.3.4
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/rncbc/qsynth.git
+  commit: ff42b352cfda5f86ee9ddeefdc854a7b1d6a466b
+
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
Qsynth 是一个使用 Qt Designer, 围绕 Qt 框架, 用 C++ 编写的 Fluidsynth GUI 前端应用程序。

![c9ea71b002eec043588a1e926f642fd3](https://github.com/linuxdeepin/linglong-hub/assets/115330610/aa0de4dd-fe33-4b67-94c7-9ec2a44ac996)

Log: finish app qsynth.
