### PR TITLE
build: add lib liblscp

### DIFF
--- a/liblscp/linglong.yaml
+++ b/liblscp/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: liblscp
+  name: liblscp
+  version: 0.9.12
+  kind: lib
+  description: |
+    liblscp is an implementation of the LinuxSampler control protocol, proposed as a C language API.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/rncbc/liblscp.git
+  commit: 611525254cc015b7b6c93c0379d6e8c1be5c6e46
+
+build:
+  kind: cmake
+
+
+
+


### PR DESCRIPTION
qsampler应用的依赖构建库。

![c8ff8ffb26d6fa390a7948fd3d18af84](https://github.com/linuxdeepin/linglong-hub/assets/115330610/3c0da437-64de-4fb7-b8e2-e09f429d10a5)

Log: finish lib liblscp.