### PR TITLE
build: add lib inih

### DIFF
--- a/inih/linglong.yaml
+++ b/inih/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: inih
+  name: inih
+  version: 0.0.57
+  kind: lib
+  description: |
+    inih (INI Not Invented Here) is a simple .INI file parser written in C. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/benhoyt/inih.git"
+  commit: 4e618f77d4bae216865c5abd972d99b1ba5031e2
+build:
+  kind: manual  
+  manual:
+    configure: |
+      meson build --prefix=${PREFIX} --libdir=${PREFIX}/lib/${TRIPLET}
+    build: |
+      ninja -C build
+    install:
+      ninja -C build install
+ 


### PR DESCRIPTION
![image](https://github.com/linuxdeepin/linglong-hub/assets/84424520/b70723f2-bf51-4a0b-8df8-9d7a708d9c4b)

a lib for exiv2.    inih (INI Not Invented Here) is a simple .INI file parser written in C.