### PR TITLE
build: add sqreenshot

### DIFF
--- a/io.github.sqreenshot/linglong.yaml
+++ b/io.github.sqreenshot/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.sqreenshot
+  name: sqreenshot
+  version: 0.1.0
+  kind: app
+  description: |
+    Simple screenshot tool based on Gnome Screenshot.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/qtilities/sqreenshot.git
+  commit: 0fbe5129db2c118a669e9e3a5d460097e6c49d0b
+
+
+build:
+  kind: cmake
+
+


### PR DESCRIPTION
sqreenshot是一款截图小工具，支持任意大小的截图。

Log: finish app sqreenshot.

![be630a3becd45797e7731f652610649f](https://github.com/linuxdeepin/linglong-hub/assets/115330610/6158792a-6216-419a-9137-6aad53482305)
