### PR TITLE
build: add voltrayke

### DIFF
--- a/io.github.voltrayke/linglong.yaml
+++ b/io.github.voltrayke/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.voltrayke
+  name: voltrayke
+  version: 0.2.0
+  kind: app
+  description: |
+    An audio volume system tray widget, inspired by PNMixer and LXQt Panel' volume plugin.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtilitools
+    version: 0.1.1
+
+source:
+  kind: git
+  url: https://github.com/qtilities/voltrayke.git
+  commit: b5e95740e100f813d4876a2df98eb63d273044e2
+
+
+build:
+  kind: cmake


### PR DESCRIPTION
Voltrayke 是一个基于 Qt 框架的音量控制应用程序，它提供了一些高级功能。

与传统桌面上的音量控制相比，Voltrayke 提供了更多的高级功能和自定义选项。它可以让用户更好地控制音量，并提供更好的用户体验。

Log: finish app voltrayke.

![65add5e4c4652a6c0cce15c61ac40ea1](https://github.com/linuxdeepin/linglong-hub/assets/115330610/727bcbe1-5b8f-4c1d-b1f7-a19fe5b0a3d1)
