### PR TITLE
build: add colorpick

### DIFF
--- a/io.github.colorpick/linglong.yaml
+++ b/io.github.colorpick/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.colorpick
+  name: colorpick
+  version: 0.1.0
+  kind: app
+  description: |
+    Colorpick is a color picker, which makes it easy to check text readability by letting you pick a background and foreground color and computing the contrast between them.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/qtilities/colorpick.git
+  commit: 6c3b195e29e3d4d7d967b1f8a16280e4393b4d69
+  patch: 
+    - patches/fix-install-001.patch
+
+
+build:
+  kind: cmake
+
+
+

--- a/io.github.colorpick/patches/fix-install-001.patch
+++ b/io.github.colorpick/patches/fix-install-001.patch
@@ -1,0 +1,16 @@
+--- ../CMakeLists.txt	2023-10-26 17:24:07.812574242 +0800
++++ ../CMakeLists.txt	2023-10-26 17:25:05.817094286 +0800
+@@ -147,7 +147,12 @@
+     install(FILES "resources/freedesktop/${PROJECT_ID}.appdata.xml"
+         DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+     )
+-    install(FILES "${PROJECT_QM_FILES}"
++    list(GET PROJECT_QM_FILES -1 FIRST_FILE)
++    install(FILES "${FIRST_FILE}"
++        DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_ID}/translations"
++    )
++    list(GET PROJECT_QM_FILES 0 SECOND_FILE)
++    install(FILES "${SECOND_FILE}"
+         DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_ID}/translations"
+     )
+     install(FILES "resources/icons/application.svg"


### PR DESCRIPTION
Colorpick 是一个颜色选择器，通过让您选择背景和前景色并计算它们之间的对比度，可以轻松检查文本的可读性。

Log: finish app colorpick.

说明：install中对make生成的部分错误源码做了替换，否则install不下来app。

![9a8346af015597ae6791b3b9177975f9](https://github.com/linuxdeepin/linglong-hub/assets/115330610/4279e795-6517-47bb-bfef-6cee0012ac7c)
