### PR TITLE
build: add QArchive

### DIFF
--- a/io.github.QArqiver/linglong.yaml
+++ b/io.github.QArqiver/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.Arqiver
+  name: Arqiver
+  version: 0.11.0
+  kind: app
+  description: |
+    a simple and lightweight Qt archive manager as a front-end for libarchive (bsdtar), gzip and 7z. Not depending on any desktop environment.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/tsujan/Arqiver.git"
+  commit: 5180e3cac07c66f5401d1bd4b59e340eb7e18b8c
+
+build:
+  kind: cmake


### PR DESCRIPTION

![Arqiver](https://github.com/linuxdeepin/linglong-hub/assets/147463620/39f7392a-1ede-4d6c-9b08-eae7738039ea)
a cross-platform C++ library that modernizes libarchive , This library helps you to extract and compress archives supported by libarchive

Log: add software name--QArchive