### PR TITLE
build: add opencv(3.4.x)

### DIFF
--- a/opencv3.4/linglong.yaml
+++ b/opencv3.4/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: opencv
+  name: opencv
+  version: 3.4.0
+  kind: lib
+  description: |
+    OpenCV: Open Source Computer Vision Library
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/opencv/opencv.git"
+  commit: 4761c2814327f1cc6c8da6e099eb3321be9be4e7
+
+build:
+  kind: cmake
+
+
+
+
+
+    


### PR DESCRIPTION
OpenCV: Open Source Computer Vision Library
库里面那个是3.2,我看github上分支最新也只只有3.4.x