### PR TITLE
build: add dsched

### DIFF
--- a/io.github.dsched/linglong.yaml
+++ b/io.github.dsched/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.dsched
+  name: dsched
+  version: 1.0.0
+  kind: app
+  description: |
+    Desktop scheduler
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/agateau/dsched.git"
+  commit: ae4c3be6ba070c27b354bf8ffd965c9a962f93b1
+
+build:
+  kind: cmake


### PR DESCRIPTION

![dsched](https://github.com/linuxdeepin/linglong-hub/assets/147463620/d870aa23-f7f2-43a7-86f2-189c95b85d84)
Desktop Schedule

Log: add software name--dsched