### PR TITLE
build: add kirigami

### DIFF
--- a/kirigami/linglong.yaml
+++ b/kirigami/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: kirigami
+  name: kirigami
+  version: 5.90.0
+  kind: lib
+  description: |
+    QtQuick plugins to build user interfaces following the KDE Human Interface Guidelines.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/KDE/kirigami.git"
+  commit: f22db4ce9849f3e7f5f755aac9ff26989698ff1a
+
+
+build:
+  kind: cmake
+
+
+
+
+
+    


### PR DESCRIPTION
![截图_选择区域_20231026174023](https://github.com/linuxdeepin/linglong-hub/assets/84424520/95cda1a3-7d96-48be-8d6b-00c726832810)
QtQuick plugins to build user interfaces following the KDE Human Interface Guidelines.
log: add lib--kirigami