### PR TITLE
build: add alligator

### DIFF
--- a/io.github.alligator/linglong.yaml
+++ b/io.github.alligator/linglong.yaml
@@ -1,0 +1,33 @@
+package:
+  id: io.github.alligator
+  name: alligator
+  version: 21.12.0
+  kind: app
+  description: |
+    Kirigami-based RSS reader.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: kcodecs/5.90.0
+  - id: kcoreaddons/5.90.0
+  - id: kconfig/5.90.0
+  - id: ki18n/5.90.0
+  - id: ksyndication/5.90.0
+    type: runtime
+
+source:
+  kind: git
+  url: "https://invent.kde.org/network/alligator.git"
+  commit: 8afa7e3fb9742504d6a339f3cc0aeee84f9e2233
+
+build:
+  kind: cmake
+
+
+
+
+
+    


### PR DESCRIPTION
![截图_选择区域_20231027130842](https://github.com/linuxdeepin/linglong-hub/assets/84424520/0ce8bed1-5d35-4807-accb-aad1c1d8e4a7)

Kirigami-based RSS reader.
log: add software--alligator