### PR TITLE
build: add BingWall

### DIFF
--- a/io.github.BingWall/linglong.yaml
+++ b/io.github.BingWall/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.BingWall
+  name: BingWall
+  version: 2.4.0
+  kind: app
+  description: |
+    Bing wallpaper of the day application for Gnome desktop
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/keshavbhatt/BingWall.git"
+  commit: bc5409e6ddb5fc1ca5d06da38c3bf8cd6efbe03b
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}


### PR DESCRIPTION

![BingWall](https://github.com/linuxdeepin/linglong-hub/assets/147463620/fa06162b-228b-426c-b736-af6314f7ef96)
Bing wallpaper of the day application for Gnome desktop

Log: add software name--BingWall