### PR TITLE
build: add music-radar

### DIFF
--- a/io.github.music-radar/linglong.yaml
+++ b/io.github.music-radar/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.music-radar
+  name: music-radar
+  version: 1.0.0
+  kind: app
+  description: |
+    Music Radar is music recognition application
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/keshavbhatt/music-radar.git"
+  commit: 4e4b5aac2815cf94c39040f7846f65dddd392efd
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}


### PR DESCRIPTION

![Music-Radar](https://github.com/linuxdeepin/linglong-hub/assets/147463620/29ee602f-7f8a-40cb-ace4-cbb9123a5acf)
Music Radar is music recognition application for Linux Desktop

Log: add software name--music-radar