### PR TITLE
build: add spotify-qt

### DIFF
--- a/io.github.spotify-qt/linglong.yaml
+++ b/io.github.spotify-qt/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.spotify-qt
+  name: spotify-qt
+  version: 3.10.0
+  kind: app
+  description: |
+    An unofficial Spotify client using Qt as a simpler, lighter alternative to the official client
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/kraxarn/spotify-qt.git"
+  commit: 9fa7eb09756ed69f10ae24ca80187e5855630f0b
+
+build:
+  kind: cmake


### PR DESCRIPTION
An unofficial Spotify client using Qt as a simpler, lighter alternative to the official client

Log: add software name--spotify-qt