### PR TITLE
build: add rssguard

### DIFF
--- a/io.github.rssguard/linglong.yaml
+++ b/io.github.rssguard/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.rssguard
+  name: rssguard
+  version: 4.5.1
+  kind: app
+  description: |
+     a simple RSS/ATOM feed reader for Windows, Linux, BSD, OS/2 or macOS which can work with RSS/ATOM/JSON/Sitemap feeds as well as many online feed services.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine
+    version: 5.15.7
+
+source:
+  kind: git
+  url: "https://github.com/martinrotter/rssguard.git"
+  commit: 4ae7ba1e356dd83bd388f9b4e036964a64874fa2
+
+build:
+  kind: cmake


### PR DESCRIPTION

![rssguard](https://github.com/linuxdeepin/linglong-hub/assets/147463620/befdd487-09b7-41dd-9bf2-efa536223443)
RSS Guard is a simple RSS/ATOM feed reader for Windows, Linux, BSD, OS/2 or macOS which can work with RSS/ATOM/JSON/Sitemap feeds as well as many online feed services.

Log: add software name--rssguard