### PR TITLE
build: add OpenTTD

### DIFF
--- a/io.github.OpenTTD/linglong.yaml
+++ b/io.github.OpenTTD/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.OpenTTD
+  name: OpenTTD
+  version: 1.3.3
+  kind: app
+  description: |
+    a transport simulation game based upon the popular game Transport Tycoon Deluxe, written by Chris Sawyer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/OpenTTD/OpenTTD.git"
+  commit: 375f24956cf9c8d315c512552f0f8e2ff167c530
+
+build:
+  kind: cmake


### PR DESCRIPTION

![OpenTTD](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a0eddd29-f3fa-4b89-b01c-503069381a57)
OpenTTD is a transport simulation game based upon the popular game Transport Tycoon Deluxe, written by Chris Sawyer.

Log: add software name--OpenTTD