### PR TITLE
build: add zeal

### DIFF
--- a/io.github.zeal/linglong.yaml
+++ b/io.github.zeal/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.zeal
+  name: zeal
+  version: 0.7.0
+  kind: app
+  description: |
+    Zeal is a simple offline documentation browser 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine
+    version: 5.15.7
+
+source:
+  kind: git
+  url: "https://github.com/zealdocs/zeal.git"
+  commit: 2cefcd45423e58283372a4c735609c284eded410
+
+build:
+  kind: cmake


### PR DESCRIPTION

![zeal](https://github.com/linuxdeepin/linglong-hub/assets/147463620/f6c74b98-0a58-447f-b549-e14dfd8d16b0)
Zeal is a simple offline documentation browser inspired by Dash.

Log: add software name--zeal