### PR TITLE
build: add texstudio

### DIFF
--- a/io.github.texstudio/linglong.yaml
+++ b/io.github.texstudio/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.texstudio
+  name: texstudio
+  version: 4.6.3
+  kind: app
+  description: |
+    TeXstudio is a fully featured LaTeX editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/texstudio-org/texstudio.git"
+  commit: 86ce072fe1df6103c289bf771fb294df4f0d3984
+
+build:
+  kind: cmake


### PR DESCRIPTION

![texstudio](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7e5b355e-b27b-40d3-bea2-b04765d269ac)
TeXstudio is a fully featured LaTeX editor.
Our goal is to make writing LaTeX documents as easy and comfortable as possible.

Log: add software name--texstudio