### PR TITLE
build: add GammaRay

### DIFF
--- a/io.github.GammaRay/linglong.yaml
+++ b/io.github.GammaRay/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.GammaRay
+  name: GammaRay
+  version: 3.0.0
+  kind: app
+  description: |
+    Leveraging the QObject introspection mechanism it allows you to observe and manipulate your application at runtime.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/KDAB/GammaRay.git"
+  commit: 93428a9da835c04162fa817678e44795d0f80033
+
+build:
+  kind: cmake


### PR DESCRIPTION

![GammaRay](https://github.com/linuxdeepin/linglong-hub/assets/147463620/71cf7dda-8fb0-4600-bfb9-a4008b3a9c78)
GammaRay is a software introspection tool for Qt applications developed by KDAB. Leveraging the QObject introspection mechanism it allows you to observe and manipulate your application at runtime.

Log: add software name--GammaRay