### PR TITLE
build: add nvtop

### DIFF
--- a/io.github.nvtop/linglong.yaml
+++ b/io.github.nvtop/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.nvtop
+  name: nvtop
+  version: 3.0.2
+  kind: app
+  description: |
+    It can handle multiple GPUs and print information about them in a htop-familiar way.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Syllo/nvtop.git
+  commit: 45a1796375cd617d16167869bb88e5e69c809468
+
+build:
+  kind: cmake


### PR DESCRIPTION

![nvtop](https://github.com/linuxdeepin/linglong-hub/assets/147463620/c230085c-38d4-4483-ad13-6e8cd8bf3322)
It can handle multiple GPUs and print information about them in a htop-familiar way.

Log: add software name--nvtop