### PR TITLE
build: add noteshrink-qt

### DIFF
--- a/io.github.noteshrink-qt/linglong.yaml
+++ b/io.github.noteshrink-qt/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.noteshrink-qt
+  name: noteshrink-qt
+  version: 10.0.0
+  kind: app
+  description: |
+    Convert scans of handwritten notes to beautiful, compact PDFs
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/clapautius/noteshrink-qt.git
+  commit: 08476f78a555bf70144eef75d960b8a9fbba82c8
+
+build:
+  kind: qmake


### PR DESCRIPTION

![noteshrink-qt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a96700c7-0004-4f47-ba26-b7b6f7f63e06)
Convert scans of handwritten notes to beautiful, compact PDFs

Log: add software name--noteshrink-qt