### PR TITLE
build: add pencil

### DIFF
--- a/io.github.pencil/linglong.yaml
+++ b/io.github.pencil/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.pencil
+  name: pencil
+  version: 0.6.6
+  kind: app
+  description: |
+    Pencil2D is an easy, intuitive tool to make 2D hand-drawn animations. Pencil2D is open source and cross-platform.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/pencil2d/pencil.git
+  commit: 127cd62212311b6b72a731c7a96b74021801bec4
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Pencil2D 是一个简单、直观的工具，用于制作 2D 手绘动画。 Pencil2D 是开源且跨平台的。

Log: finish app pencil.

![9166e39f520e342f070d4f34f5c2bbd6](https://github.com/linuxdeepin/linglong-hub/assets/115330610/1eaf5dff-c6bd-4d03-8759-70928b5c0b23)
