### PR TITLE
build: add tiled

### DIFF
--- a/io.github.tiled/linglong.yaml
+++ b/io.github.tiled/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.tiled
+  name: tiled
+  version: 1.8.6
+  kind: app
+  description: |
+    Tiled is a general purpose tile map editor for all tile-based games, such as RPGs, platformers or Breakout clones.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/mapeditor/tiled.git"
+  commit: e79f4fe8ee98d0087f35cbfce21f6bfedfaf6d22
+
+
+build:
+  kind: qmake
+      
+
+
+
+
+
+    


### PR DESCRIPTION
![截图_选择区域_20231027171004](https://github.com/linuxdeepin/linglong-hub/assets/84424520/122d84a2-7e3d-48ec-8971-b573960b47ec)
Tiled is a general purpose tile map editor for all tile-based games, such as RPGs, platformers or Breakout clones.

log: add software--tiled