### PR TITLE
build: add MrWriter

### DIFF
--- a/io.github.MrWriter/linglong.yaml
+++ b/io.github.MrWriter/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.MrWriter
+  name: MrWriter
+  version: 0.0.7
+  kind: app
+  description: |
+    Notetaking and blackboard replacement application. Inspired by Xournal. Written in C++/Qt for Linux / Windows / Mac.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libzip
+    version: 1.5.1.8
+
+source:
+  kind: git
+  url: https://github.com/unruhschuh/MrWriter.git
+  commit: 9b9ae093fc194ef7e782fb31d0e8aad71c3349ad
+  patch: patches/fix-desktop-001.patch
+
+
+build:
+  kind: cmake 
+

--- a/io.github.MrWriter/patches/fix-desktop-001.patch
+++ b/io.github.MrWriter/patches/fix-desktop-001.patch
@@ -1,0 +1,9 @@
+--- ../CMakeLists.txt	2023-10-28 09:26:36.902747000 +0800
++++ ../CMakeLists.txt	2023-10-28 09:45:32.959267025 +0800
+@@ -166,4 +166,5 @@
+ 
+ target_link_libraries(MrWriter ${LIBS})
+ 
+-install(TARGETS MrWriter DESTINATION ${CMAKE_BINARY_DIR}/appdir/usr/bin)
++install(TARGETS MrWriter DESTINATION /opt/apps/io.github.MrWriter/files/bin)
++install(PROGRAMS ./MrWriter.desktop DESTINATION /opt/apps/io.github.MrWriter/files/share/applications)


### PR DESCRIPTION
一款写字板应用程序， 用 C++/Qt 编写，适用于 Linux / Windows / Mac。

Log: finish app MrWriter.

![a14388903b2dfcce29660eccdd5c6a78](https://github.com/linuxdeepin/linglong-hub/assets/115330610/9c48db52-33b8-429c-b2cb-4411fd32938f)
