### PR TITLE
build: add hmtimer

### DIFF
--- a/io.github.hmtimer/linglong.yaml
+++ b/io.github.hmtimer/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.hmtimer
+  name: hmtimer
+  version: 3.2.1
+  kind: app
+  description: |
+    A graphical shutdown timer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/cges30901/hmtimer.git
+  commit: bd87442639cc9ec44b35ba195caf73bc171ed2a1
+  patch: 
+    - patches/fix-001.patch
+    - patches/fix-002.patch
+
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      qmake -makefile ${conf_args} ${extra_args} ./hmtimer.pro
+
+
+

--- a/io.github.hmtimer/patches/fix-001.patch
+++ b/io.github.hmtimer/patches/fix-001.patch
@@ -1,0 +1,15 @@
+--- ./hmtimer.pro	2023-11-01 14:38:29.385004000 +0800
++++ ./hmtimer.pro	2023-11-01 14:43:06.921408219 +0800
+@@ -7,10 +7,10 @@
+ 
+ install_desktop.files=io.github.cges30901.hmtimer.desktop
+ CONFIG(flatpak):install_desktop.path=/app/share/applications
+-else:install_desktop.path=/usr/share/applications
++else:install_desktop.path=$$PREFIX/share/applications
+ 
+ install_appdata.files=io.github.cges30901.hmtimer.appdata.xml
+ CONFIG(flatpak):install_appdata.path=/app/share/appdata
+-else:install_appdata.path=/usr/share/appdata
++else:install_appdata.path=$$PREFIX/share/appdata
+ 
+ INSTALLS+=install_desktop install_appdata

--- a/io.github.hmtimer/patches/fix-002.patch
+++ b/io.github.hmtimer/patches/fix-002.patch
@@ -1,0 +1,31 @@
+--- ../src/src.pro	2023-11-01 14:38:29.445005000 +0800
++++ ../src/src.pro	2023-11-01 14:57:29.403727718 +0800
+@@ -53,23 +53,23 @@
+ 
+ install_bin.files=hmtimer
+ CONFIG(flatpak):install_bin.path=/app/bin
+-else:install_bin.path=/usr/bin
++else:install_bin.path=$$PREFIX/bin
+ 
+ install_translation.files=language/hmtimer_*.qm
+ CONFIG(flatpak):install_translation.path=/app/share/hmtimer
+-else:install_translation.path=/usr/share/hmtimer
++else:install_translation.path=$$PREFIX/share/hmtimer
+ 
+ install_icon128.files=icon/128x128/io.github.cges30901.hmtimer.png
+ CONFIG(flatpak):install_icon128.path=/app/share/icons/hicolor/128x128/apps
+-else:install_icon128.path=/usr/share/icons/hicolor/128x128/apps
++else:install_icon128.path=$$PREFIX/share/icons/hicolor/128x128/apps
+ 
+ install_icon64.files=icon/64x64/io.github.cges30901.hmtimer.png
+ CONFIG(flatpak):install_icon64.path=/app/share/icons/hicolor/64x64/apps
+-else:install_icon64.path=/usr/share/icons/hicolor/64x64/apps
++else:install_icon64.path=$$PREFIX/share/icons/hicolor/64x64/apps
+ 
+ install_icon48.files=icon/48x48/io.github.cges30901.hmtimer.png
+ CONFIG(flatpak):install_icon48.path=/app/share/icons/hicolor/48x48/apps
+-else:install_icon48.path=/usr/share/icons/hicolor/48x48/apps
++else:install_icon48.path=$$PREFIX/share/icons/hicolor/48x48/apps
+ 
+ INSTALLS+=install_bin install_translation install_icon128 install_icon64 install_icon48
+ 


### PR DESCRIPTION
hmtimer 是一个适用于 Linux 和 Windows 的图形化关机计时器。 它使您可以在一段时间后关闭、关闭显示器、重新启动或播放声音。

Log: finish app hmtimer.

![28896b9d91bda359f2f4913e7483fb1c](https://github.com/linuxdeepin/linglong-hub/assets/115330610/f8b3eced-2ed3-4b3e-a06f-a0d2f12c63da)
