### PR TITLE
build: add wxHexEditor

### DIFF
--- a/io.github.wxHexEditor/linglong.yaml
+++ b/io.github.wxHexEditor/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.wxHexEditor
+  name: wxHexEditor
+  version: 0.24.0
+  kind: app
+  description: |
+    wxHexEditor official GIT.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: wxWidgets
+    version: 3.2.3
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/EUA/wxHexEditor.git
+  commit: 516cfd842eea49a2c0f1649d0a0b2894113f4228
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+
+

--- a/io.github.wxHexEditor/patches/fix-001.patch
+++ b/io.github.wxHexEditor/patches/fix-001.patch
@@ -1,0 +1,13 @@
+--- ../CMakeLists.txt	2023-10-28 21:30:31.753728000 +0800
++++ ../CMakeLists.txt	2023-10-28 18:09:51.878305184 +0800
+@@ -52,6 +52,10 @@
+ 	wxHexEditor PRIVATE mhash udis ${wxWidgets_LIBRARIES}
+ )
+ 
++install(TARGETS wxHexEditor DESTINATION /opt/apps/io.github.wxHexEditor/files/bin)
++install(PROGRAMS resources/wxHexEditor.desktop DESTINATION /opt/apps/io.github.wxHexEditor/files/share/applications)
++install(FILES resources/wxHexEditor.ico DESTINATION /opt/apps/io.github.wxHexEditor/files/share/applications)
++
+ if (WIN32)
+ 	target_link_libraries(wxHexEditor PRIVATE mhash udis ${wxWidgets_LIBRARIES} uxtheme oleacc psapi ws2_32)
+ endif()


### PR DESCRIPTION
适用于 Linux、Windows 和 MacOSX 的免费十六进制编辑器/磁盘编辑器。

Log: finish app wxHexEditor.

![9728dc459e95adce743493c5eeab1f3d](https://github.com/linuxdeepin/linglong-hub/assets/115330610/c8479c99-1f61-4c43-b6b1-ea9dd80c0576)
