### PR TITLE
build: add QTeletextMaker

### DIFF
--- a/io.github.QTeletextMaker/linglong.yaml
+++ b/io.github.QTeletextMaker/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.QTeletextMaker
+  name: QTeletextMaker
+  version: 0.6.2
+  kind: app
+  description: |
+     QTeletextMaker is a teletext page editor in development. It is written in C++ using the Qt 5 widget libraries, and released under the GNU General Public License v3.0
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/gkthemac/QTeletextMaker.git"
+  commit: 975932156698fc3458d68d7f819be120d6200584
+  patch:
+    - patches/0001-fix-install.patch
+
+build:
+  kind: qmake

--- a/io.github.QTeletextMaker/patches/0001-fix-install.patch
+++ b/io.github.QTeletextMaker/patches/0001-fix-install.patch
@@ -1,0 +1,45 @@
+From d34f97ddcc980c61b1ecdd1f547c20d85a21fa2b Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Sun, 29 Oct 2023 12:06:50 +0800
+Subject: [PATCH] fix-install
+
+---
+ qteletextmaker.desktop | 9 +++++++++
+ qteletextmaker.pro     | 8 ++++++--
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+ create mode 100644 qteletextmaker.desktop
+
+diff --git a/qteletextmaker.desktop b/qteletextmaker.desktop
+new file mode 100644
+index 0000000..6f9baa4
+--- /dev/null
++++ b/qteletextmaker.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Name=qteletextmaker
++Categories=Game;Qt;
++Comment=teletext page editor
++Exec=qteletextmaker
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/qteletextmaker.pro b/qteletextmaker.pro
+index 476b1ed..beae8a7 100644
+--- a/qteletextmaker.pro
++++ b/qteletextmaker.pro
+@@ -43,5 +43,9 @@ SOURCES       = decode.cpp \
+ RESOURCES     = qteletextmaker.qrc
+ 
+ # install
+-target.path = /usr/local/bin
+-INSTALLS += target
++BINDIR  = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = qteletextmaker.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
 ![截图_选择区域_20231029120744](https://github.com/linuxdeepin/linglong-hub/assets/84424520/4f920c79-00fd-43b0-9a4b-964af72e9d47)
QTeletextMaker is a teletext page editor in development. It is written in C++ using the Qt 5 widget libraries, and released under the GNU General Public License v3.0

log: add software--QTeletextMaker