### PR TITLE
build: add qbr

### DIFF
--- a/io.github.qbr/linglong.yaml
+++ b/io.github.qbr/linglong.yaml
@@ -1,0 +1,35 @@
+package:
+  id: io.github.qbr
+  name: qbr
+  version: 0.0.6
+  kind: app
+  description: |
+    Simple e-Book reader, written on C++ with Qt library.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+  - id: quazip
+    version: 0.9.1
+    type: runtime
+    source:
+      kind: git
+      url: https://github.com/stachenov/quazip.git
+      commit: 6938d8b108b09ebb14ef25542abd2d9108f8e036
+    build:
+      kind: cmake
+
+source:
+  kind: git
+  url: https://github.com/moose-kazan/qbr.git
+  commit: b4a1433b5ba9dcf226f8f8399c9b25da6b89fa55
+
+variables:
+  extra_args: |
+    INCLUDEPATH+=/runtime/include
+
+build:
+  kind: qmake


### PR DESCRIPTION
Simple e-Book reader, written on C++ with Qt library.

Log: add software name--qbr

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/e96dbf71-beb2-4ea3-958b-39dcbfc55750)
编译成功