### PR TITLE
build: add capslock-status

### DIFF
--- a/io.github.capslock-status/linglong.yaml
+++ b/io.github.capslock-status/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.capslock-status
+  name: capslock-status
+  version: 1.0.0
+  kind: app
+  description: |
+    display an icon in system tray to indicate the status of capslock.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/cges30901/capslock-status.git
+  commit: fd2bbecf9f4564657e645734c6af0c493cd44fa8
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+  manual :
+    configure: |
+      mkdir build && cd build 
+      qmake -makefile ${conf_args} ${extra_args} ../capslock.pro
+
+

--- a/io.github.capslock-status/patches/fix-001.patch
+++ b/io.github.capslock-status/patches/fix-001.patch
@@ -1,0 +1,32 @@
+--- ../capslock.pro	2023-10-29 09:53:51.748830000 +0800
++++ ../capslock.pro	2023-10-29 10:02:35.075829134 +0800
+@@ -16,3 +16,29 @@
+ RESOURCES=capslock.qrc
+ 
+ LIBS+=-lX11
++
++
++DESTDIR = /opt/apps/io.github.capslock-status
++
++target.path = $${DESTDIR}/files/bin
++DESKTOP_FILE = ./QalculaTor.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=0.1.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=capslock-status' >> $$DESKTOP_FILE")
++system("echo 'Comment=capslock-status, a tool for calculate.' >> $$DESKTOP_FILE")
++system("echo 'Exec=/opt/apps/io.github.capslock-status/files/bin/capslock' >> $$DESKTOP_FILE")
++system("echo 'Icon=/source/capslock_off.png' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$DESTDIR/files/share/applications
++
++INSTALLS += target desktop
++
++
++
++
++
++
++


### PR DESCRIPTION
一款小工具，当键盘做大小写切换时，右下角任务栏会显示托盘图标进行常驻状态展示。

Log: finish app capslock-status.

![7667ba974e36c94ea1f274a4e2446487](https://github.com/linuxdeepin/linglong-hub/assets/115330610/03c3d7ca-3ce8-4378-bed0-185107376e43)
