### PR TITLE
build: add qt-unit-converter

### DIFF
--- a/io.github.qt-unit-converter/linglong.yaml
+++ b/io.github.qt-unit-converter/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.qt-unit-converter
+  name: qt-unit-converter
+  version: 1.0.0
+  kind: app
+  description: |
+    A program for unit conversions made using the Qt framework.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/30vam/qt-unit-converter.git
+  commit: f77635d8f4e3a3623309a5e2e6625081b22eeeea
+  patch:
+    - patches/add-desktop-file-patch.patch
+    - patches/install-desktop-file-patch.patch
+
+build:
+  kind: qmake

--- a/io.github.qt-unit-converter/patches/add-desktop-file-patch.patch
+++ b/io.github.qt-unit-converter/patches/add-desktop-file-patch.patch
@@ -1,0 +1,14 @@
+diff --git a/qt-unit-converter.desktop b/qt-unit-converter.desktop
+new file mode 100644
+index 0000000..31a4cf4
+--- /dev/null
++++ b/qt-unit-converter.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Type=Application
++Name=Qt unit converter
++Exec=qt-unit-converter %f
++Icon=qt-unit-converter
++Categories=Qt;
++GenericName=A program for unit conversions made using the Qt framework.
++

--- a/io.github.qt-unit-converter/patches/install-desktop-file-patch.patch
+++ b/io.github.qt-unit-converter/patches/install-desktop-file-patch.patch
@@ -1,0 +1,17 @@
+diff --git a/qt-unit-converter.pro b/qt-unit-converter.pro
+index fc8b963..ba10648 100644
+--- a/qt-unit-converter.pro
++++ b/qt-unit-converter.pro
+@@ -36,7 +36,12 @@ CONFIG += embed_translations
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+ else: unix:!android: target.path = /opt/$${TARGET}/bin
++target.path = $$PREFIX/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
++desktop.path = $$PREFIX/share/applications
++desktop.files += qt-unit-converter.desktop
++INSTALLS += desktop
++
+ RESOURCES += \
+     icons.qrc


### PR DESCRIPTION
A program for unit conversions made using the Qt framework.

Log: add software name--qt-unit-converter

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/af536f9c-6af5-4c9a-b19d-b1dc4c3a8fed)
编译成功