### PR TITLE
build: add MedianXLOfflineTools

### DIFF
--- a/io.github.MedianXLOfflineTools/linglong.yaml
+++ b/io.github.MedianXLOfflineTools/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.MedianXLOfflineTools
+  name: MedianXLOfflineTools
+  version: 0.6.4
+  kind: app
+  description: |
+    Character manager for Diablo 2 - Median XL mod.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/kambala-decapitator/MedianXLOfflineTools.git
+  commit: e603beb7e435290409505be5ee9bcc3faec021ff
+  patch:
+    - patches/add-desktop-file-patch.patch
+    - patches/install-desktop-file-patch.patch
+
+variables:
+  extra_args: |
+    MedianXLOfflineTools.pro
+
+build:
+  kind: qmake

--- a/io.github.MedianXLOfflineTools/patches/add-desktop-file-patch.patch
+++ b/io.github.MedianXLOfflineTools/patches/add-desktop-file-patch.patch
@@ -1,0 +1,13 @@
+diff --git a/MedianXLOfflineTools.desktop b/MedianXLOfflineTools.desktop
+new file mode 100644
+index 00000000..3f21270e
+--- /dev/null
++++ b/MedianXLOfflineTools.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Type=Application
++Name=Median XL Offline Tools
++Exec=MedianXLOfflineTools %f
++Icon=MedianXLOfflineTools
++Categories=Qt;
++GenericName=Character manager for Diablo 2 - Median XL mod.

--- a/io.github.MedianXLOfflineTools/patches/install-desktop-file-patch.patch
+++ b/io.github.MedianXLOfflineTools/patches/install-desktop-file-patch.patch
@@ -1,0 +1,14 @@
+diff --git a/MedianXLOfflineTools.pro b/MedianXLOfflineTools.pro
+index 36fd0348..c258445f 100644
+--- a/MedianXLOfflineTools.pro
++++ b/MedianXLOfflineTools.pro
+@@ -1,2 +1,9 @@
+ TARGET = MedianXLOfflineTools
+ include(app.pri)
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += MedianXLOfflineTools.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION
Character manager for Diablo 2 - Median XL mod.

Log: add software name--MedianXLOfflineTools

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/0fff0d51-e261-4a34-aac2-445a0bd0dd69)
编译成功