### PR TITLE
build: add TomatoTimer

### DIFF
--- a/io.github.TomatoTimer/linglong.yaml
+++ b/io.github.TomatoTimer/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.TomatoTimer
+  name: TomatoTimer
+  version: 0.1.2
+  kind: app
+  description: |
+    A Simple Pomodoro Timer that lives in the Menu Bar 🍅.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/lmartinking/TomatoTimer.git
+  commit: bf6845f981d0383890fd20c23d0c9b327e9b9381
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake 
+  manual :
+    configure: |
+      qmake -makefile ${conf_args} ${extra_args} ./TomatoTimer.pro
+

--- a/io.github.TomatoTimer/patches/fix-001.patch
+++ b/io.github.TomatoTimer/patches/fix-001.patch
@@ -1,0 +1,24 @@
+--- ../TomatoTimer.pro	2023-10-29 15:40:09.432896000 +0800
++++ ../TomatoTimer.pro	2023-11-01 15:43:31.443857512 +0800
+@@ -43,3 +43,21 @@
+     SOURCES += systemsounds/systemsounds_unix.cpp
+     SOURCES += notifications/notifications_unix.cpp
+ }
++
++
++DESTDIR = $$PRFEIX
++DESKTOP_FILE = ./TomatoTimer.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.2' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=TomatoTimer' >> $$DESKTOP_FILE")
++system("echo 'Comment=TomatoTimer, a tool.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$DESTDIR/bin/TomatoTimer' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$DESTDIR/files/share/applications
++target.path = $${DESTDIR}/files/bin
++INSTALLS += desktop target
++


### PR DESCRIPTION
位于菜单栏中的简单番茄计时器,能根据用户设定来运行计时功能，方便提醒用户时间。

Log: finish app TomatoTimer.

![30c33f23bffa11aaa4660cf1a0265ef4](https://github.com/linuxdeepin/linglong-hub/assets/115330610/1330e2d5-9226-483b-ae80-8145eff8cb74)
