### PR TITLE
build: add DoomRunner

### DIFF
--- a/io.github.DoomRunner/linglong.yaml
+++ b/io.github.DoomRunner/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.DoomRunner
+  name: DoomRunner
+  version: 1.8.2
+  kind: app
+  description: |
+    Preset-oriented graphical launcher of various ported Doom engines (an alternative to ZDL).
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Youda008/DoomRunner.git
+  commit: 4a61c9a55a952d03e448503cf81f395953950b30
+  patch: patches/fix-001.patch
+
+build:
+  kind: qmake 
+  manual:
+    configure: |
+      qmake -makefile ${conf_args} ${extra_args} ./DoomRunner.pro

--- a/io.github.DoomRunner/patches/fix-001.patch
+++ b/io.github.DoomRunner/patches/fix-001.patch
@@ -1,0 +1,32 @@
+--- ../DoomRunner.pro	2023-11-01 19:46:44.266923000 +0800
++++ ../DoomRunner.pro	2023-11-01 19:48:47.611413456 +0800
+@@ -148,8 +148,10 @@
+ 
+ #-- deployment -----------------------------------
+ 
++DESTDIR = $$PREFIX
++
+ # add "INSTALL_DIR=/custom/path" to the qmake command to override this default value
+-isEmpty(INSTALL_DIR): INSTALL_DIR = /usr/bin
++isEmpty(INSTALL_DIR): INSTALL_DIR = $$DESTDIR/bin
+ 
+ unix: !android
+ {
+@@ -157,3 +159,17 @@
+ }
+ 
+ !isEmpty(target.path): INSTALLS += target
++
++DESKTOP_FILE = ./DoomRunner.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.8.1' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=DoomRunner' >> $$DESKTOP_FILE")
++system("echo 'Comment=DoomRunner, a tool for calculate.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$DESTDIR/bin/DoomRunner' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$DESTDIR/share/applications
++INSTALLS += desktop


### PR DESCRIPTION
Doom Runner 是另一个具有图形用户界面的常见 Doom 源端口（如 GZDoom、Zandronum、PrBoom 等）的启动器。它是用 C++ 和 Qt 编写的，其设计围绕各种多文件修改的预设理念（带有变异器的 Brutal Doom、带有 UDV 的 Project Brutality、Complex Doom Clusterfuck，...），以允许在它们之间一键切换并尽量减少重复性工作。

Log: finish app DoomRunner.

![8af819b4518e048f19643aac5fce916d](https://github.com/linuxdeepin/linglong-hub/assets/115330610/a5647913-b94b-4fb5-8a6e-85465b43e569)


