### PR TITLE
build: add lib SDL2_ttf again

### DIFF
--- a/SDL2_ttf/linglong.yaml
+++ b/SDL2_ttf/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: SDL2_ttf
+  name: SDL2_ttf
+  version: 2.0.18
+  kind: lib
+  description: |
+    Support for TrueType (.ttf) font files with Simple Directmedia Layer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: automake
+    version: 1.16.5
+
+source:
+  kind: git
+  url: https://github.com/libsdl-org/SDL_ttf.git
+  commit: 3e702ed9bf400b0a72534f144b8bec46ee0416cb
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./configure ${conf_args} ${extra_args}
+


### PR DESCRIPTION
这是SDL_ttf依赖库的修复版，解决pc和动态库的问题。

![238aa60b5b699a447ac25ac179e3d51c](https://github.com/linuxdeepin/linglong-hub/assets/115330610/4ae5dcff-dd35-4e9e-8555-6aab309c74bb)
