### PR TITLE
build: add zeit

### DIFF
--- a/io.github.zeit/linglong.yaml
+++ b/io.github.zeit/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.zeit
+  name: zeit
+  version: 0.6.0
+  kind: app
+  description: |
+    Qt frontend to crontab and at
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/loimu/zeit.git
+  commit: 33085ca53336517bfc74c72ac02ec7b56ea4ddba
+    
+build:
+  kind: cmake


### PR DESCRIPTION

![zeit](https://github.com/linuxdeepin/linglong-hub/assets/147463620/6ee54a2a-01d6-4509-ba92-b7f91a7b1998)
Qt frontend to crontab and at

Log: add software name--zeit