### PR TITLE
build: add LibreMines

### DIFF
--- a/io.github.LibreMines/linglong.yaml
+++ b/io.github.LibreMines/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.LibreMines
+  name: LibreMines
+  version: 1.9.1
+  kind: app
+  description: |
+    LibreMines is a Free/Libre and Open Source software Qt based Minesweeper clone available for GNU/Linux, FreeBSD and Windows systems.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Bollos00/LibreMines.git
+  commit: fe9c638d4af2555d2e1315314a60b7987ec44e1d
+
+build:
+  kind: cmake


### PR DESCRIPTION

![LibreMines](https://github.com/linuxdeepin/linglong-hub/assets/147463620/42a6c97c-2d2f-48f1-98d1-2b2644c64301)
LibreMines is a Free/Libre and Open Source software Qt based Minesweeper clone available for GNU/Linux, FreeBSD and Windows systems.

Log: add software name--LibreMines