### PR TITLE
build: add fdt-viewer

### DIFF
--- a/io.github.fdt-viewer/linglong.yaml
+++ b/io.github.fdt-viewer/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.fdt-viewer
+  name: fdt-viewer
+  version: 0.8.1
+  kind: app
+  description: |
+    Flattened Device Tree Viewer written in Qt.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dev-0x7C6/fdt-viewer.git
+  commit: 93f2a8d7d2d8e57df97d2009982b0a6008b61bd8
+
+build:
+  kind: cmake


### PR DESCRIPTION

![fdt-viewer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/82352d88-5487-4d7e-975b-527f9eb2d1cd)
Flattened Device Tree Viewer

Log: add software name--fdt-viewer