### PR TITLE
build: add wii-region-check

### DIFF
--- a/io.github.wii-region-check/linglong.yaml
+++ b/io.github.wii-region-check/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.wii-region-check
+  name: wii-region-check
+  version: 0.1.0
+  kind: app
+  description: |
+    Wii tool for checking game region.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dev-0x7C6/wii-region-check.git
+  commit: a9e50306a54ff526588a699bb5738333c9826ce8
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.wii-region-check/patches/0001-install.patch
+++ b/io.github.wii-region-check/patches/0001-install.patch
@@ -1,0 +1,27 @@
+From 46351791654f5b91f7aa8ee15719ddbb9ea40427 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 29 Oct 2023 21:00:29 +0800
+Subject: [PATCH] install
+
+---
+ wiiregioncheck.pro | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/wiiregioncheck.pro b/wiiregioncheck.pro
+index a052a05..dbc207b 100644
+--- a/wiiregioncheck.pro
++++ b/wiiregioncheck.pro
+@@ -64,3 +64,9 @@ SOURCES += src/main.cpp src/mainwindow.cpp
+ HEADERS  += src/mainwindow.h
+ FORMS    += forms/mainwindow.ui
+ 
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =res/wiiregioncheck.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION

![wii-region-check](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ec1aa9c6-d2b9-4765-be49-29adfd3a4efb)
Wii tool for checking game region.

Log: add software name--wii-region-check