### PR TITLE
build: add qwiiload

### DIFF
--- a/io.github.qwiiload/linglong.yaml
+++ b/io.github.qwiiload/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qwiiload
+  name: qwiiload
+  version: 0.80.0
+  kind: app
+  description: |
+    Wii homebrew executable uploader written in Qt.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dev-0x7C6/qwiiload.git
+  commit: e1926fe128a5289edf8692c590e546f5d64b7c06
+
+build:
+  kind: qmake


### PR DESCRIPTION

![qwiiload](https://github.com/linuxdeepin/linglong-hub/assets/147463620/185aa25a-02f3-4754-8e85-736a174afd1f)
Wii homebrew executable uploader

Log: add software name--qwiiload