### PR TITLE
build: add HotShots

### DIFF
--- a/io.github.HotShots/linglong.yaml
+++ b/io.github.HotShots/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.HotShots
+  name: HotShots
+  version: 2.2.0
+  kind: app
+  description: |
+    HotShots is an application for capturing screens and saving them in a variety of image formats as well as adding annotations and graphical data
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/obiwankennedy/HotShots.git
+  commit: e3712ae13d6f58e640069e8370fea6c15ffe241c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.HotShots/patches/0001-install.patch
+++ b/io.github.HotShots/patches/0001-install.patch
@@ -1,0 +1,41 @@
+From fe9406aeb51b70d66e0829a189b0f7d3ee430709 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 29 Oct 2023 21:16:39 +0800
+Subject: [PATCH] install
+
+---
+ HotShots.pro | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/HotShots.pro b/HotShots.pro
+index a0b11e6..ffc23e6 100644
+--- a/HotShots.pro
++++ b/HotShots.pro
+@@ -359,8 +359,6 @@ unix:!macx {
+     # generate desktop file
+     VERSION = $$system(grep VERSION src/AppSettings.h | awk \' { print $NF }\' | sed   \'s/\"//g\')
+     system( sh  packaging/hotshots-desktop.sh  $$INSTALL_PREFIX $$VERSION > hotshots.desktop )
+-    desktop.files += hotshots.desktop
+-    desktop.path = $$MYAPP_INSTALL_DESKTOP
+ 
+     icons.files += res/hotshots.png
+     icons.path = $$MYAPP_INSTALL_PIXMAPS
+@@ -373,7 +371,10 @@ unix:!macx {
+     system( gzip -9 -f hotshots.1  )
+     manual.files += hotshots.1.gz
+     manual.path = $$MYAPP_INSTALL_MAN
+-
+-    INSTALLS += target transl data desktop icons manual mimetype
+-}
+-
++	BINDIR = $$PREFIX/bin
++	DATADIR = $$PREFIX/share
++	target.path = $$BINDIR
++	desktop.files =hotshots.desktop
++	desktop.path = $$DATADIR/applications/
++	INSTALLS += target desktop
++}
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION

![HotShots](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9dd75c07-9a63-472a-b29e-bfa21e577fa6)
HotShots is an application for capturing screens and saving them in a variety of image formats as well as adding annotations and graphical data .

Log: add software name--HotShots