### PR TITLE
build: add TexasSolver

### DIFF
--- a/io.github.TexasSolver/linglong.yaml
+++ b/io.github.TexasSolver/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.TexasSolver
+  name: TexasSolver
+  version: 0.2.0
+  kind: app
+  description: |
+    A open sourced, extremely efficient Texas Hold'em and short deck solver.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/bupticybee/TexasSolver.git
+  commit: 7d912fc3025df6eaab102d01682a2acc4736e436
+
+build:
+  kind: qmake


### PR DESCRIPTION

![TexasSolver](https://github.com/linuxdeepin/linglong-hub/assets/147463620/83ec69ed-569f-4a87-bbf0-6ff779929f3d)
A open sourced, extremely efficient Texas Hold'em and short deck solver.

Log: add software name--TexasSolver