### PR TITLE
build: update liblscp

### DIFF
--- a/liblscp/linglong.yaml
+++ b/liblscp/linglong.yaml
@@ -1,23 +1,24 @@
 package:
   id: liblscp
   name: liblscp
-  version: 0.9.12
+  version: 0.9.13
   kind: lib
   description: |
     liblscp is an implementation of the LinuxSampler control protocol, proposed as a C language API.
-
 runtime:
   id: org.deepin.Runtime
   version: 23.0.0
+
 
 source:
   kind: git
   url: https://github.com/rncbc/liblscp.git
   commit: 611525254cc015b7b6c93c0379d6e8c1be5c6e46
 
+
+variables:
+  conf_args: |
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_INSTALL_LIBDIR=/lib/${TRIPLET}
 build:
   kind: cmake
-
-
-
-


### PR DESCRIPTION
上一次合入的liblscp,在使用过程中，发现lib与include并不在runtime文件夹中，而是做了一层嵌套进行了单独存储，导致使用沙箱无法读取对应依赖环境。