### PR TITLE
build add openPilotLog

### DIFF
--- a/io.github.openPilotLog/linglong.yaml
+++ b/io.github.openPilotLog/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.openPilotLog
+  name: openPilotLog
+  version: 1.0.0
+  kind: app
+  description: |
+    the free and open source airline pilot logbook application.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/fiffty-50/openPilotLog.git"
+  commit: d71d01cd94a10fcb4a1243397c24291e3bc74f43
+  patch: 
+    - patches/0001-fix-desktop.patch
+
+build:
+  kind: cmake

--- a/io.github.openPilotLog/patches/0001-fix-desktop.patch
+++ b/io.github.openPilotLog/patches/0001-fix-desktop.patch
@@ -1,0 +1,36 @@
+From fadb88d11fc487e43c909ca99f67df7811560e9c Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Mon, 30 Oct 2023 14:28:41 +0800
+Subject: [PATCH] fix-desktop
+
+---
+ CMakeLists.txt | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b0b183..b205fc1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -255,4 +255,19 @@ set_source_files_properties(${app_icon_macos} PROPERTIES MACOSX_PACKAGE_LOCATION
+ # target_link_libraries(openPilotLog PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Sql Qt${QT_VERSION_MAJOR}::Network OpenSSL::SSL)
+ target_link_libraries(openPilotLog PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Sql Qt${QT_VERSION_MAJOR}::Network)
+ 
++
+ install(TARGETS openPilotLog DESTINATION bin)
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=openPilotLog.desktop
++Exec=openPilotLog
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/openPilotLog.desktop "${DESKTOP_FILE_CONTENT}")
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/openPilotLog.desktop DESTINATION /opt/apps/io.github.openPilotLog/files/share/applications)
++
++#install(TARGETS duckstation-qt DESTINATION bin)
+-- 
+2.33.1
+


### PR DESCRIPTION
![截图_选择区域_20231030142947](https://github.com/linuxdeepin/linglong-hub/assets/84424520/c6e5a71f-2faa-475c-8396-a7c9cec58e51)
Welcome to openPilotLog, the free and open source airline pilot logbook application! You can find the latest release here. Please not that this is still an early testing version.

log: add software--openPilotLog