### PR TITLE
build: add file-commander

### DIFF
--- a/io.github.file-commander/linglong.yaml
+++ b/io.github.file-commander/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.file-commander
+  name: file-commander
+  version: 0.9.7.1
+  kind: app
+  description: |
+    The goal of the project is to provide consistent user experience across all the major desktop systems.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/VioletGiraffe/file-commander.git
+  commit: 0f539f6c011390cfc1308aa498bb57650d54b3a2
+
+build:
+  kind: qmake


### PR DESCRIPTION

![file-commander](https://github.com/linuxdeepin/linglong-hub/assets/147463620/52d6fcfc-2aa3-4a2b-8ceb-5ff0db976f31)
The goal of the project is to provide consistent user experience across all the major desktop systems.

Log: add software name--file-commander