### PR TITLE
build: add qditstat

### DIFF
--- a/io.github.qdirstat/linglong.yaml
+++ b/io.github.qdirstat/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qdirstat
+  name: qdirstat
+  version: 1.8.1
+  kind: app
+  description: |
+    
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/shundhammer/qdirstat.git
+  commit: 8174478b4ac59ccf31a14edca9dfaf4b6012e9b6
+
+build:
+  kind: qmake


### PR DESCRIPTION
QDirStat is a graphical application to show where your disk space has gone and to help you to clean it up.

Log: add software name--qdirstat
![qdirstat](https://github.com/linuxdeepin/linglong-hub/assets/147463620/3ceccfa7-9873-4e9e-9710-3ecd5d98387c)
