### PR TITLE
build: add Datapicker

### DIFF
--- a/io.github.Datapicker/linglong.yaml
+++ b/io.github.Datapicker/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.Datapicker
+  name: Datapicker
+  version: 1.0.0
+  kind: app
+  description: |
+    This open source, digitizing software converts an image file showing a graph or map, into numbers.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/ankitwagadre/Datapicker.git
+  commit: 29937eeeb4392e3fbfd2c80734634af91fcd42bf
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      mkdir build && cd build
+      qmake -makefile ${conf_args} ${extra_args} ../Datapicker.pro
+

--- a/io.github.Datapicker/patches/fix-001.patch
+++ b/io.github.Datapicker/patches/fix-001.patch
@@ -1,0 +1,36 @@
+--- ../Datapicker.pro	2023-10-29 17:57:28.932991000 +0800
++++ ../Datapicker.pro	2023-10-29 18:00:40.512282612 +0800
+@@ -4,7 +4,7 @@
+ #
+ #-------------------------------------------------
+ 
+-QT       += core gui
++QT += core gui
+ 
+ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+ 
+@@ -21,3 +21,23 @@
+ 
+ FORMS    += mainwindow.ui \
+     Datapicker.ui
++
++
++DESTDIR = /opt/apps/io.github.Datapicker/files
++
++DESKTOP_FILE = ./Datapicker.desktop
++
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=Datapicker' >> $$DESKTOP_FILE")
++system("echo 'Comment=Datapicker, a tool.' >> $$DESKTOP_FILE")
++system("echo 'Exec=/opt/apps/io.github.Datapicker/files/bin/Datapicker' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$DESTDIR/share/applications
++target.path = $${DESTDIR}/bin
++INSTALLS += desktop
++INSTALLS += target
+\ 文件尾没有换行符


### PR DESCRIPTION
这种开源数字化软件将显示图形或地图的图像文件转换为数字。图像文件可以来自扫描仪、数码相机或屏幕截图。这些数字可以在屏幕上读取，并写入或复制到电子表格中。

Log: finish app Datapicker.

![9cfb01f61b53943616a60e38a0dd103d](https://github.com/linuxdeepin/linglong-hub/assets/115330610/baff4344-bce4-44a0-8f27-dfa7db0965f1)
