### PR TITLE
build: add xclicker

### DIFF
--- a/io.github.xclicker/linglong.yaml
+++ b/io.github.xclicker/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.xclicker
+  name: xcliker
+  version: 1.5.0
+  kind: app
+  description: |
+    XClicker is an open-source, easy to use, feature-rich, blazing fast Autoclicker for linux desktops using x11.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/robiot/xclicker.git
+  commit: e37c6092df2a0b179d02762413bd1abf62de02f9
+  patch: patches/fix-001.patch
+
+build:
+  kind: manual
+  manual:
+    configure: |
+    build: |
+      make release
+    install: |
+

--- a/io.github.xclicker/patches/fix-001.patch
+++ b/io.github.xclicker/patches/fix-001.patch
@@ -1,0 +1,21 @@
+--- ../src/meson.build	2023-10-27 16:31:07.030467000 +0800
++++ ../src/meson.build	2023-10-30 14:12:38.362016777 +0800
+@@ -16,4 +16,18 @@
+     'utils.c',
+     xclicker_resources,
+     dependencies: deps,
++    install : true,
++    install_dir: '/opt/apps/io.github.xclicker/files/bin'
+ )
++
++desktop_contents = '''
++[Desktop Entry]
++Name=xclicker
++Exec=xclicker
++Icon=xclicker
++Type=Application
++Categories=Utility;
++'''
++
++configure_file(output: 'xclicker.desktop',  configuration: {'DESKTOP_CONTENTS': desktop_contents})
++install_data('/source/build/release/src/xclicker.desktop', install_dir: '/opt/apps/io.github.xclicker/files/share/applications' )


### PR DESCRIPTION
XClicker 是一款开源、易于使用、功能丰富、速度极快的 Autoclicker，适用于使用 x11 的 Linux 桌面。

Log: finish add xclicker.

![f40f1641300b782f62c7ffbc3db1a16f](https://github.com/linuxdeepin/linglong-hub/assets/115330610/a339179e-b02c-441d-9e87-9922c4600988)
