### PR TITLE
build: add QSerialTerminal

### DIFF
--- a/io.github.QSerialTerminal/linglong.yaml
+++ b/io.github.QSerialTerminal/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.QSerialTerminal
+  name: QSerialTerminal
+  version: 1.0.0
+  kind: app
+  description: |
+    A simple, cross-platform serial port terminal application written with Qt/QML.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport
+    type: runtime
+    version: 5.15.7
+
+source:
+  kind: git
+  url: https://github.com/alex-spataru/QSerialTerminal.git
+  commit: 976d7f8d7e3d439edccd76634e39f7d2cec0bf75
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.QSerialTerminal/patches/0001-install.patch
+++ b/io.github.QSerialTerminal/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From e349ecbafd3e4ec54cf160125ea44eee0d0e57a1 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 31 Oct 2023 13:15:01 +0800
+Subject: [PATCH] install
+
+---
+ QSerialTerminal.pro | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/QSerialTerminal.pro b/QSerialTerminal.pro
+index b6b40dd..1fd2e94 100644
+--- a/QSerialTerminal.pro
++++ b/QSerialTerminal.pro
+@@ -60,15 +60,21 @@ macx* {
+ }
+ 
+ linux:!android {
+-    TARGET = qserialterminal
++    #TARGET = qserialterminal
+     
+-    target.path = /usr/bin
+-    icon.path = /usr/share/pixmaps
+-    desktop.path = /usr/share/applications
+-    icon.files += deploy/linux/*.svg
+-    desktop.files += deploy/linux/*.desktop
++   # target.path = /usr/bin
++   icon.path = /usr/share/pixmaps
++  #  desktop.path = /usr/share/applications
++   icon.files += deploy/linux/*.svg
++ #   desktop.files += deploy/linux/*.desktop
+ 
+     INSTALLS += target desktop icon
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = deploy/linux/qserialterminal.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+ }
+ 
+ #-------------------------------------------------------------------------------
+-- 
+2.33.1
+


### PR DESCRIPTION

![QSerialTerminal](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e302e743-3add-4786-a626-bc0eafa03528)
A simple, cross-platform serial port terminal application written with Qt/QML.

Log: add software name--QSerialTerminal