### PR TITLE
build: add playdraughts

### DIFF
--- a/io.github.playdraughts/linglong.yaml
+++ b/io.github.playdraughts/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.playdraughts
+  name: playdraughts
+  version: 0.2.0
+  kind: app
+  description: |
+     Play Draughts is a Linux human vs computer draughts game developed using C++ and Qt5.15.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/crispinalan/playdraughts.git"
+  commit: abcb9410aade3984a74947007536a5d080c90480
+  patch: patches/0001-fix-install.patch 
+
+build:
+  kind: cmake
+  manual: 
+    configure: |
+      cd src
+      cmake -B ${build_dir} ${conf_args} ${extra_args}

--- a/io.github.playdraughts/patches/0001-fix-install.patch
+++ b/io.github.playdraughts/patches/0001-fix-install.patch
@@ -1,0 +1,38 @@
+From ce473117d231671f99652d7a6a51a9265b92c5a6 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Tue, 31 Oct 2023 23:28:01 +0800
+Subject: [PATCH] fix-install
+
+---
+ src/CMakeLists.txt | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 202be83..e7fd143 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.22.0)
++cmake_minimum_required(VERSION 3.21.0)
+ 
+ project(draughts)
+ 
+@@ -72,3 +72,15 @@ INSTALL(TARGETS
+ )
+ 
+ 
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=draughts.desktop
++Exec=draughts
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/draughts.desktop "${DESKTOP_FILE_CONTENT}")
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/draughts.desktop DESTINATION share/applications)
+-- 
+2.33.1
+


### PR DESCRIPTION
![截图_选择区域_20231031232933](https://github.com/linuxdeepin/linglong-hub/assets/84424520/4c0ef41a-bb1f-4e31-a81f-4d930985c19d)
Play Draughts is a Linux human vs computer draughts game developed using C++ and Qt5.15.

log: add game--playdraughts