### PR TITLE
build: add Counter-Desktop

### DIFF
--- a/io.github.Counter-Desktop/linglong.yaml
+++ b/io.github.Counter-Desktop/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.Counter-Desktop
+  name: Counter-Desktop
+  version: 2.9.0
+  kind: app
+  description: |
+     Counter is desktop application that counts the number of characters and words in the text.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/DionysusBenstein/Counter-Desktop.git"
+  commit: 8a1cf3963ee31613249a55afa88b3ba8fd6c3ec8
+  patch: patches/0001-fix-install.patch
+
+build:
+  kind: qmake
+  

--- a/io.github.Counter-Desktop/patches/0001-fix-install.patch
+++ b/io.github.Counter-Desktop/patches/0001-fix-install.patch
@@ -1,0 +1,45 @@
+From dd35ed6e9546671cfead24894e93394cc1999d4c Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Wed, 1 Nov 2023 12:14:57 +0800
+Subject: [PATCH] fix-install
+
+---
+ Counter.desktop | 8 ++++++++
+ Counter.pro     | 9 +++++++++
+ 2 files changed, 17 insertions(+)
+ create mode 100644 Counter.desktop
+
+diff --git a/Counter.desktop b/Counter.desktop
+new file mode 100644
+index 0000000..885f793
+--- /dev/null
++++ b/Counter.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=tool;Qt;
++Exec=Counter
++Name=Counter
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/Counter.pro b/Counter.pro
+index 53fd000..f6744cb 100644
+--- a/Counter.pro
++++ b/Counter.pro
+@@ -34,3 +34,12 @@ HEADERS += \
+     Counter.h
+ 
+ RC_FILE = images/icons/icon.rc
++
++
++#install role
++BINDIR  = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = Counter.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
![截图_选择区域_20231101121537](https://github.com/linuxdeepin/linglong-hub/assets/84424520/cb9d4297-a1d3-4e9b-a84d-7aa640e68033)
Counter is desktop application that counts the number of characters and words in the text.

log: add software--Counter-Desktop