### PR TITLE
build: add hydratool

### DIFF
--- a/io.github.hydratool/linglong.yaml
+++ b/io.github.hydratool/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.hydratool
+  name: hydratool
+  version: 3.2.1
+  kind: app
+  description: |
+     This repository contains host software (Linux/Windows) for HydraBus with HydraFW firmware, a project to produce a low cost, open source multi-tool hardware for anyone interested in
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/hydrabus/hydratool.git"
+  commit: 95a3dbdbf183f6b84703517b5e83f097baf40ee9
+  patch: patches/0001-fix-install.patch
+build:
+  kind: qmake
+
+    

--- a/io.github.hydratool/patches/0001-fix-install.patch
+++ b/io.github.hydratool/patches/0001-fix-install.patch
@@ -1,0 +1,46 @@
+From 89dd9e7df40ad20642807dfbd22e719f6f18ee0f Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Wed, 1 Nov 2023 18:04:02 +0800
+Subject: [PATCH] fix-install
+
+---
+ hydratool.desktop | 8 ++++++++
+ hydratool.pro     | 9 +++++++++
+ 2 files changed, 17 insertions(+)
+ create mode 100644 hydratool.desktop
+
+diff --git a/hydratool.desktop b/hydratool.desktop
+new file mode 100644
+index 0000000..eed4722
+--- /dev/null
++++ b/hydratool.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=tool;Qt;
++Exec=hydratool
++Name=hydratool
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/hydratool.pro b/hydratool.pro
+index 132ca87..5f9de06 100644
+--- a/hydratool.pro
++++ b/hydratool.pro
+@@ -57,3 +57,12 @@ RESOURCES += \
+     hydratool.qrc
+ 
+ RC_FILE = resources.rc
++
++
++#install role
++BINDIR  = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = hydratool.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
![截图_选择区域_20231101180550](https://github.com/linuxdeepin/linglong-hub/assets/84424520/a4860a63-b637-44cb-9238-88658cbdb00e)
This repository contains host software (Linux/Windows) for HydraBus with HydraFW firmware, a project to produce a low cost, open source multi-tool hardware for anyone interested in Learning/Developping/Debugging/Hacking/Penetration Testing for basic or advanced embedded hardware.

log: add software--hydratool