### PR TITLE
build: add Qt-based-video-editor

### DIFF
--- a/io.github.Qt-based-video-editor/linglong.yaml
+++ b/io.github.Qt-based-video-editor/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.Qt-based-video-editor
+  name: Qt-based-video-editor
+  version: 0.0.1
+  kind: app
+  description: |
+    A Qt-based(Qt5) video editing software. Using FFmpeg as the backend.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/Ethkuil/Qt-based-video-editor.git"
+  commit: cce3146d223420b169d32bf008dd193c2597da30
+  patch: patches/install.patch
+
+build:
+  kind: cmake

--- a/io.github.Qt-based-video-editor/patches/install.patch
+++ b/io.github.Qt-based-video-editor/patches/install.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index edff589..c4cfe2b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,3 +33,8 @@ target_link_libraries(${PROJECT_NAME}
+     Qt5::MultimediaWidgets
+     Qt5::Widgets
+ )
++
++
++
++install(TARGETS QtBasedVideoEditor DESTINATION bin)
++install(PROGRAMS veido.desktop DESTINATION share/applications)
+diff --git a/veido.desktop b/veido.desktop
+new file mode 100644
+index 0000000..53b5f27
+--- /dev/null
++++ b/veido.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=Qt-based-video-editor
++Exec=QtBasedVideoEditor
++Terminal=false
+\ No newline at end of file


### PR DESCRIPTION
A Qt-based(Qt5) video editing software. Using FFmpeg as the backend.

log: add app--Qt-based-video-editor
![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/16534502-529c-41b1-a586-8874fa110723)
