### PR TITLE
build: add QTRVSim

### DIFF
--- a/io.github.QTRVSim/linglong.yaml
+++ b/io.github.QTRVSim/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.QTRVSim
+  name: QTRVSim
+  version: 0.9.5
+  kind: app
+  description: |
+    QtRVSim is experimentally available for WebAssembly and it can be run in most browsers without installation. QtRVSim online
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/cvut/qtrvsim.git"
+  commit: ea0a68eb0fde014839a31a0430527e1755b76458
+
+build:
+  kind: cmake


### PR DESCRIPTION
QtRVSim is experimentally available for WebAssembly and it can be run in most browsers without installation. QtRVSim online

log: add app--QTRVSim

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/55f37a15-8f24-4c6f-805a-56802d7671b3)
