### PR TITLE
build: add ecalc

### DIFF
--- a/io.github.ecalc/linglong.yaml
+++ b/io.github.ecalc/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.ecalc
+  name: ecalc
+  version: 0.0.1
+  kind: app
+  description: |
+    This is a collection of handy calculators for electronics engineers.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/luqasz/ecalc.git"
+  commit: c4c1d6bc979149046fc703bc7876d386a3f04263
+  patch: patches/install.patch
+
+build:
+  kind: cmake

--- a/io.github.ecalc/patches/install.patch
+++ b/io.github.ecalc/patches/install.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba15a97..e6022b0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,3 +39,6 @@ target_link_libraries(${PROJECT_NAME}
+ 
+ 
+ include(packaging)
++
++install(TARGETS ecalc DESTINATION bin)
++install(PROGRAMS ecalc.desktop DESTINATION share/applications)
+diff --git a/ecalc.desktop b/ecalc.desktop
+new file mode 100644
+index 0000000..a42e156
+--- /dev/null
++++ b/ecalc.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=ecalc
++Exec=ecalc
++Terminal=false
+\ No newline at end of file


### PR DESCRIPTION
This is a collection of handy calculators for electronics engineers.

log: add app--ecalc

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/c1603dad-0974-40fc-8042-e3d62b2e811d)
