### PR TITLE
build: add qxgedit

### DIFF
--- a/io.github.qxgedit/linglong.yaml
+++ b/io.github.qxgedit/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.qxgedit
+  name: qxgedit
+  version: 0.9.12
+  kind: app
+  description: |
+    QXGEdit is a Qt GUI for editing MIDI System Exclusive files for XG devices (eg. Yamaha DB50XG).
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtscxml/5.15.7
+
+source:
+  kind: git
+  url: https://github.com/rncbc/qxgedit.git
+  commit: b12055b65a95ff550111fa37201efa03feee28a7
+
+build:
+  kind: cmake


### PR DESCRIPTION
QXGEdit 是一个用于编辑 MIDI 系统专用文件的 Qt GUI
适用于 XG 设备（例如 Yamaha DB50XG）。

Log: finish app qxgedit.

![f1968e4b0b942a78245cbd8240f32268](https://github.com/linuxdeepin/linglong-hub/assets/115330610/b3274592-2428-4429-a6d4-f74b8a5cf484)
