### PR TITLE
build: add qtscreenshottool

### DIFF
--- a/com.gitee.qtscreenshottool/linglong.yaml
+++ b/com.gitee.qtscreenshottool/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: com.gitee.qtscreenshottool
+  name: qtscreenshottool
+  version: 0.0.1
+  kind: app
+  description: |
+    A shortcut to screenshots, for the user to bring the ultimate screenshot experience
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://gitee.com/hotlab/qt-screenshot-tool.git"
+  commit: 16765fdfc898490904582b674ac54ab3ced1e7b7
+  patch: patches/0001-install.patch
+
+
+build:
+  kind: qmake
+  manual :
+    configure: |
+      cd 'Lite Shot'
+      qmake -makefile ${conf_args} ${extra_args}

--- a/com.gitee.qtscreenshottool/patches/0001-install.patch
+++ b/com.gitee.qtscreenshottool/patches/0001-install.patch
@@ -1,0 +1,56 @@
+From 31ddde3cff6da05a849bb4e61e232dcc738ab95a Mon Sep 17 00:00:00 2001
+From: xwqlikepsl <2242484264@qq.com>
+Date: Wed, 29 Nov 2023 09:34:09 +0800
+Subject: [install.patch_] install
+
+---
+ Lite Shot/Qt-Screenshot.pro    | 14 ++++++++++----
+ Lite Shot/QtScreenShot.desktop |  6 ++++++
+ 2 files changed, 16 insertions(+), 4 deletions(-)
+ create mode 100644 Lite Shot/QtScreenShot.desktop
+
+diff --git a/Lite Shot/Qt-Screenshot.pro b/Lite Shot/Qt-Screenshot.pro
+index 825797f..fbdc91c 100644
+--- a/Lite Shot/Qt-Screenshot.pro	
++++ b/Lite Shot/Qt-Screenshot.pro	
+@@ -3,7 +3,8 @@ QT       += core gui
+ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+ 
+ CONFIG += c++11
+-
++TARGET = Qt-Screenshot
++TEMPLATE = app
+ # The following define makes your compiler emit warnings if you use
+ # any Qt feature that has been marked deprecated (the exact warnings
+ # depend on your compiler). Please consult the documentation of the
+@@ -26,6 +27,11 @@ FORMS += \
+     widgetwindow.ui
+ 
+ # Default rules for deployment.
+-qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
+-!isEmpty(target.path): INSTALLS += target
++unix: {
++target.path = $${PREFIX}/bin
++INSTALLS += target
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = QtScreenShot.desktop
++INSTALLS += unix_desktop
++}
++
+diff --git a/Lite Shot/QtScreenShot.desktop b/Lite Shot/QtScreenShot.desktop
+new file mode 100644
+index 0000000..5537618
+--- /dev/null
++++ b/Lite Shot/QtScreenShot.desktop	
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=QtScreenShot
++Exec=Qt-Screenshot
++Terminal=false
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A shortcut to screenshots, for the user to bring the ultimate screenshot experience

log: add app--qtscreenshottool

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/e63df6f5-a421-41bb-b54c-a349cff7bd6b)

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/ed5d20e1-a5ea-4800-a7a9-37e5f062fec6)
