### PR TITLE
build: add RepRaptor

### DIFF
--- a/io.github.RepRaptor/linglong.yaml
+++ b/io.github.RepRaptor/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.RepRaptor
+  name: RepRaptor
+  version: 0.3.8
+  kind: app
+  description: |
+    A Qt RepRap gcode sender/host controller aimed to be fast and minimalistic.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/NeoTheFox/RepRaptor.git
+  commit: cf81418938640c5ed0d48925934cc0fa4f568b22
+
+build:
+  kind: qmake


### PR DESCRIPTION
 Qt RepRap gcode sender/host controller aimed to be fast and minimalistic.

Log: add software name--RepRaptor![RepRaptor](https://github.com/linuxdeepin/linglong-hub/assets/147463620/859bb769-8dce-443f-9020-fb66743b918c)