### PR TITLE
build: add qiniu_Qt

### DIFF
--- a/io.github.qiniu_Qt/linglong.yaml
+++ b/io.github.qiniu_Qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.qiniu_Qt
+  name: qiniu_Qt
+  version: 0.0.1
+  kind: app
+  description: |
+    The use of cloud and map bed can greatly simplify the chain of access to the process, the picture or file drag and drop to the“Cloud and map bed” can be triggered!
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://gitee.com/xuxincode/qiniu_Qt.git"
+  commit: 054222a41ec735b6f756d88867a731f8d11f95a7
+  patch: patches/install.patch
+
+build:
+  kind: qmake

--- a/io.github.qiniu_Qt/patches/install.patch
+++ b/io.github.qiniu_Qt/patches/install.patch
@@ -1,0 +1,31 @@
+diff --git a/qiniu_demo.pro b/qiniu_demo.pro
+index fd72d86..abdd86a 100644
+--- a/qiniu_demo.pro
++++ b/qiniu_demo.pro
+@@ -28,3 +28,13 @@ FORMS    += mainwindow.ui \
+ 
+ RESOURCES += \
+     asset.qrc
++
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = qiuniu_Qt.desktop
++INSTALLS += unix_desktop
++
++
++
+diff --git a/qiuniu_Qt.desktop b/qiuniu_Qt.desktop
+new file mode 100644
+index 0000000..ac58869
+--- /dev/null
++++ b/qiuniu_Qt.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=qiniu_Qt
++Exec=qiniu_Qt
++Terminal=false
+\ No newline at end of file


### PR DESCRIPTION
The use of cloud and map bed can greatly simplify the chain of access to the process, the picture or file drag and drop to the“Cloud and map bed” can be triggered!

log: add app--qiniu_Qt

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/3920f13e-5648-49e2-ad00-efeeeadd8f94)
