### PR TITLE
build: add ObjGui

### DIFF
--- a/io.github.ObjGui/linglong.yaml
+++ b/io.github.ObjGui/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.ObjGui
+  name: ObjGui
+  version: 1.0.0
+  kind: app
+  description: |
+    ObjGui uses objdump to disassemble executables, analyzes the data, and then provides an easy way to navigate through the disassembly.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/jubal-R/ObjGui.git
+  commit: b9a60fa8505dda184a8d6922ddeeb35137a2432d
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}

--- a/io.github.ObjGui/patches/0001-install.patch
+++ b/io.github.ObjGui/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From 1c1f41c229ec2cf2dacfbe9130b61756b65cb9c2 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 3 Nov 2023 18:53:42 +0800
+Subject: [PATCH] install
+
+---
+ src/ObjGui.desktop | 8 ++++++++
+ src/ObjGui.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 src/ObjGui.desktop
+
+diff --git a/src/ObjGui.desktop b/src/ObjGui.desktop
+new file mode 100644
+index 0000000..e8f7dd9
+--- /dev/null
++++ b/src/ObjGui.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=ObjGui
++Name=ObjGui
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/src/ObjGui.pro b/src/ObjGui.pro
+index 1e95091..ee6daad 100644
+--- a/src/ObjGui.pro
++++ b/src/ObjGui.pro
+@@ -48,3 +48,10 @@ DISTFILES += \
+     fonts/Anonymous Pro B.ttf \
+     fonts/Anonymous Pro BI.ttf \
+     fonts/Anonymous Pro I.ttf
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =ObjGui.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
ObjGui uses objdump to disassemble executables, analyzes the data, and then provides an easy way to navigate through the disassembly.

Log: add software name--ObjGui
![ObjGui](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e5568bc8-a21f-4ee4-95c8-2911f5acf7f6)
