### PR TITLE
build: add qmarkdowntextedit

### DIFF
--- a/io.github.qmarkdowntextedit/linglong.yaml
+++ b/io.github.qmarkdowntextedit/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.qmarkdowntextedit
+  name: qmarkdowntextedit
+  version: 1.0.0
+  kind: app
+  description: |
+    A C++ Qt QPlainTextEdit  with markdown highlighting support and a lot of other extras
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/pbek/qmarkdowntextedit.git"
+  commit: a7ed8197fad0e1a314ea1f4c4373eeb192a31963
+  patch: patches/0001-install.patch
+
+
+build:
+  kind: cmake

--- a/io.github.qmarkdowntextedit/patches/0001-install.patch
+++ b/io.github.qmarkdowntextedit/patches/0001-install.patch
@@ -1,0 +1,47 @@
+From 30abe4867a2d1cb985341de26960822a98cad53b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 5 Nov 2023 10:21:36 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt                      | 4 ++--
+ build_dir/qmarkdowntextedit.desktop | 8 ++++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+ create mode 100644 build_dir/qmarkdowntextedit.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a3af903..e347283 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-﻿cmake_minimum_required(VERSION 3.16) # Qt requires CMake 3.16
++cmake_minimum_required(VERSION 3.16) # Qt requires CMake 3.16
+ project(qmarkdowntextedit LANGUAGES CXX VERSION 1.0.0)
+ 
+ #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+@@ -99,7 +99,7 @@ install(TARGETS qmarkdowntextedit
+ # Add PkgConfig config file
+ configure_file(qmarkdowntextedit.pc.in ${CMAKE_BINARY_DIR}/qmarkdowntextedit.pc @ONLY)
+ install(FILES ${CMAKE_BINARY_DIR}/qmarkdowntextedit.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+-
++install(PROGRAMS ${CMAKE_BINARY_DIR}/qmarkdowntextedit.desktop DESTINATION share/applications)
+ # Install exe
+ if(QMARKDOWNTEXTEDIT_EXE)
+     install(TARGETS qmarkdowntextedit-exe DESTINATION bin)
+diff --git a/build_dir/qmarkdowntextedit.desktop b/build_dir/qmarkdowntextedit.desktop
+new file mode 100644
+index 0000000..a3d773a
+--- /dev/null
++++ b/build_dir/qmarkdowntextedit.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=qmarkdowntextedit
++Name=qmarkdowntextedit
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+-- 
+2.33.1
+


### PR DESCRIPTION
A C++ Qt QPlainTextEdit widget with markdown highlighting support and a lot of other extras.

Log: add software name--qmarkdowntextedit
![qmarkdowntextedit](https://github.com/linuxdeepin/linglong-hub/assets/147463620/197e7ed9-2ab0-490d-b68e-38015088adb4)
