### PR TITLE
build: add GitQlient

### DIFF
--- a/io.github.GitQlient/linglong.yaml
+++ b/io.github.GitQlient/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.GitQlient
+  name: deepin-demo
+  version: 1.6.2   
+  kind: app
+  description: |
+    GitQlient, pronounced as git+client (/gɪtˈklaɪənt/) is a multi-platform Git client originally forked from QGit.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/francescmm/GitQlient.git"
+  commit: 4d197a8720c5978dddb3f36ae790793891e592e9
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.GitQlient/patches/0001-install.patch
+++ b/io.github.GitQlient/patches/0001-install.patch
@@ -1,0 +1,40 @@
+From 02f620146839f11074c1d6ad57eaf13629d2a5a6 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 3 Nov 2023 21:43:48 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt              | 2 ++
+ build_dir/GitQlient.desktop | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+ create mode 100644 build_dir/GitQlient.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a19f69c2..375c5375 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,3 +158,5 @@ install(TARGETS ${APP_NAME}
+     BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+     LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+ )
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/GitQlient.desktop DESTINATION share/applications)
+\ No newline at end of file
+diff --git a/build_dir/GitQlient.desktop b/build_dir/GitQlient.desktop
+new file mode 100644
+index 00000000..c3b0e55c
+--- /dev/null
++++ b/build_dir/GitQlient.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=GitQlient
++Name=GitQlient
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
GitQlient, pronounced as git+client (/gɪtˈklaɪənt/) is a multi-platform Git client originally forked from QGit.

Log: add software name--GitQlient
![GitQlient](https://github.com/linuxdeepin/linglong-hub/assets/147463620/37643c35-ca5a-4b79-8b90-44ab8491d5fd)
