### PR TITLE
build: add Steganographia

### DIFF
--- a/io.github.Steganographia/linglong.yaml
+++ b/io.github.Steganographia/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.Steganographia
+  name: Steganographia
+  version: 1.0.0
+  kind: app
+  description: |
+    A computer-aided design system for material resistance problems.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/shotInLeg/Steganographia.git
+  commit: 83d381fe887d876cf25163c55eceeee4b8a79b92
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}

--- a/io.github.Steganographia/patches/0001-install.patch
+++ b/io.github.Steganographia/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From 3107e18a6d66dcd645881a29e00c433989964325 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 4 Nov 2023 11:32:45 +0800
+Subject: [PATCH] install
+
+---
+ src/Steganographia.desktop | 8 ++++++++
+ src/Steganographia.pro     | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 src/Steganographia.desktop
+
+diff --git a/src/Steganographia.desktop b/src/Steganographia.desktop
+new file mode 100644
+index 0000000..420b547
+--- /dev/null
++++ b/src/Steganographia.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=Steganographia
++Name=Steganographia
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/src/Steganographia.pro b/src/Steganographia.pro
+index 1f0db4a..5080511 100644
+--- a/src/Steganographia.pro
++++ b/src/Steganographia.pro
+@@ -37,3 +37,11 @@ HEADERS += \
+ 
+ FORMS += \
+         steganographia.ui
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =Steganographia.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
 A computer-aided design system for material resistance problems.

Log: add software name--Steganographia
![Steganographia](https://github.com/linuxdeepin/linglong-hub/assets/147463620/61e3d0a7-3eae-4908-8bcc-78f6df975466)
