### PR TITLE
build: add SSopromatCAD

### DIFF
--- a/io.github.SSopromatCAD/linglong.yaml
+++ b/io.github.SSopromatCAD/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.SSopromatCAD
+  name: SSopromatCAD
+  version: 1.0.0
+  kind: app
+  description: |
+    A computer-aided design system for material resistance problems.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/shotInLeg/SSopromatCAD.git
+  commit: ee8e2ed47a7a81f8317cc17d78ba89ba54a65527
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.SSopromatCAD/patches/0001-install.patch
+++ b/io.github.SSopromatCAD/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From a135d9c5e3865e830564e90121706ee6b52f904e Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 4 Nov 2023 11:42:56 +0800
+Subject: [PATCH] install
+
+---
+ SSopromatCAD.desktop | 8 ++++++++
+ SSopromatCAD.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 SSopromatCAD.desktop
+
+diff --git a/SSopromatCAD.desktop b/SSopromatCAD.desktop
+new file mode 100644
+index 0000000..3ea4484
+--- /dev/null
++++ b/SSopromatCAD.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=SSopromatCAD
++Name=SSopromatCAD
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/SSopromatCAD.pro b/SSopromatCAD.pro
+index b13f702..36eab5f 100644
+--- a/SSopromatCAD.pro
++++ b/SSopromatCAD.pro
+@@ -26,3 +26,10 @@ FORMS    += ssopromatcad.ui \
+ 
+ RESOURCES += \
+     recourses.qrc
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =SSopromatCAD.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
    A computer-aided design system for material resistance problems.

Log: add software name--SSopromatCAD
![SSopromatCAD](https://github.com/linuxdeepin/linglong-hub/assets/147463620/93830244-782a-4da8-8faa-6aea7b6e1409)
