### PR TITLE
build: add owoncontrol-qt

### DIFF
--- a/io.github.owoncontrol-qt/linglong.yaml
+++ b/io.github.owoncontrol-qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.owoncontrol-qt
+  name: owoncontrol-qt
+  version: 1.0.0
+  kind: app
+  description: |
+    This is the next step from my "owoncontrol" project and provides a simple user interface for the end user to allow control of an SDS7102v oscilloscope via USB.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/7oxicshadow/owoncontrol-qt.git
+  commit: 80c74c4a432bb00f8a3fc577b7e11931b03f99dd
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.owoncontrol-qt/patches/0001-install.patch
+++ b/io.github.owoncontrol-qt/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From fe6c33bf0c04598603bfacaa027422e208a769e5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 4 Nov 2023 12:56:07 +0800
+Subject: [PATCH] install
+
+---
+ owoncontrol-qt.desktop | 8 ++++++++
+ owoncontrol-qt.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 owoncontrol-qt.desktop
+
+diff --git a/owoncontrol-qt.desktop b/owoncontrol-qt.desktop
+new file mode 100644
+index 0000000..b8ab324
+--- /dev/null
++++ b/owoncontrol-qt.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=owoncontrol-qt
++Name=owoncontrol-qt
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/owoncontrol-qt.pro b/owoncontrol-qt.pro
+index 724585b..b274183 100644
+--- a/owoncontrol-qt.pro
++++ b/owoncontrol-qt.pro
+@@ -35,3 +35,10 @@ FORMS    += owoncontrol.ui \
+     consetting.ui
+ 
+ LIBS     += -lusb-1.0
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =owoncontrol-qt.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
Owon oscilloscope USB  in QT

Log: add software name--owoncontrol-qt
![owoncontrol-qt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/92f04ba0-822c-4c22-a94c-4ee8ea30ea86)
