### PR TITLE
build: add qawno

### DIFF
--- a/io.github.qawno/linglong.yaml
+++ b/io.github.qawno/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.qawno
+  name: qawno
+  version: 1.0.0
+  kind: app
+  description: |
+    Qawno is a simple cross-platform Pawn editor with syntax highlighting and script compilation support.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/Zeex/qawno.git"
+  commit: 46f3f5c07f3e459ef1c2cfe0d43e3b3045343cdc
+  patch: patches/install.patch
+  
+build:
+  kind: cmake

--- a/io.github.qawno/patches/install.patch
+++ b/io.github.qawno/patches/install.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e6b7d01..bb0b7c8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -236,3 +236,6 @@ elseif(APPLE)
+ endif()
+ 
+ include(CPack)
++
++install(TARGETS qawno DESTINATION bin)
++install(PROGRAMS qawno.desktop DESTINATION share/applications)
+diff --git a/qawno.desktop b/qawno.desktop
+new file mode 100644
+index 0000000..4d79bca
+--- /dev/null
++++ b/qawno.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=qawno
++Exec=qawno
++Terminal=false
+\ No newline at end of file


### PR DESCRIPTION
Qawno is a simple cross-platform Pawn editor with syntax highlighting and script compilation support.

log: add app--qawno

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/76952a19-8ae6-4a62-9c47-2d3f322931a1)
