### PR TITLE
build: add HJ-Editor

### DIFF
--- a/io.github.HJ-Editor/linglong.yaml
+++ b/io.github.HJ-Editor/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.HJ-Editor
+  name: HJ-Editor
+  version: 0.0.1
+  kind: app
+  description: |
+    A simple C + + IDE with Lenovo, code highlighting, compile and run, and more
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/m-iDev-0792/HJ-Editor.git"
+  commit: bf4d55f2522ca24850f136f79efcf1e3e893ebba
+  patch: patches/install.patch
+
+build:
+  kind: qmake

--- a/io.github.HJ-Editor/patches/install.patch
+++ b/io.github.HJ-Editor/patches/install.patch
@@ -1,0 +1,31 @@
+diff --git a/HJ-Editor.desktop b/HJ-Editor.desktop
+new file mode 100644
+index 0000000..c0f812b
+--- /dev/null
++++ b/HJ-Editor.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=HJ-Editor 
++Exec=HJ-Editor 
++Terminal=false
+\ No newline at end of file
+diff --git a/HJ-Editor.pro b/HJ-Editor.pro
+index d3189ea..4e3f851 100644
+--- a/HJ-Editor.pro
++++ b/HJ-Editor.pro
+@@ -45,3 +45,13 @@ RESOURCES += \
+     image.qrc
+ 
+ ICON = icon.icns
++
++unix: {
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = HJ-Editor.desktop
++INSTALLS += unix_desktop
++}
++


### PR DESCRIPTION
A simple C + + IDE with Lenovo, code highlighting, compile and run, and more

log: add app--HJ-Editor

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/9c2ee64e-58ff-48ae-9390-50d3325d1d31)
