### PR TITLE
build: add Cataclysm

### DIFF
--- a/io.github.Cataclysm/linglong.yaml
+++ b/io.github.Cataclysm/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.Cataclysm
+  name: Cataclysm
+  version: 23.03.01
+  kind: app
+  description: |
+     Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+variables:
+  extra_args: |
+    -DCMAKE_BUILD_TYPE=Release
+
+source:
+  kind: git
+  url: "https://github.com/CleverRaven/Cataclysm-DDA.git"
+  commit: f295ac055490c51ae75995dd20ce9437e0b982ce
+  patch: patches/0001-fix-install.patch
+build:
+  kind: cmake
+
+    

--- a/io.github.Cataclysm/patches/0001-fix-install.patch
+++ b/io.github.Cataclysm/patches/0001-fix-install.patch
@@ -1,0 +1,31 @@
+From 7644d21920bddecf9ae6393c96d06305e923c1ac Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Mon, 6 Nov 2023 23:11:54 +0800
+Subject: [PATCH] fix-install
+
+---
+ CMakeLists.txt | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b45e7104ba..a42004d42c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -427,3 +427,14 @@ add_custom_target(uninstall
+         "${CMAKE_COMMAND}"
+         -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+ 
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=cataclysm.desktop
++Exec=cataclysm
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/cataclysm.desktop "${DESKTOP_FILE_CONTENT}")
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/cataclysm.desktop DESTINATION share/applications)
+-- 
+2.33.1
+


### PR DESCRIPTION

![截图_选择区域_20231107000718](https://github.com/linuxdeepin/linglong-hub/assets/84424520/1ce23f74-f2de-460c-b592-afec38867e76)
Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world.

log: add sofware--Cataclysm