### PR TITLE
build: add rektangles

### DIFF
--- a/io.github.rektangles/linglong.yaml
+++ b/io.github.rektangles/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.rektangles
+  name: rektangles
+  version: 0.0.1
+  kind: app
+  description: |
+     Implementation of a Japanese puzzle game known as shikaku. A game for PinePhone (and for desktop).
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: kirigami/5.90.0
+  - id: ki18n/5.90.0
+
+source:
+  kind: git
+  url: https://github.com/Helguli/rektangles.git
+  commit: cef71fa0cc5445a3fcb9bf36f4be35f0ba1b5953
+
+build:
+  kind: cmake
+


### PR DESCRIPTION

![截图_选择区域_20231107145641](https://github.com/linuxdeepin/linglong-hub/assets/84424520/7f41dada-b4de-4c2a-af5f-77291c95eb83)

Implementation of a Japanese puzzle game known as shikaku. A game for PinePhone (and for desktop).

log: add game--rektangles