### PR TITLE
build: add SVGStationPlanEditor

### DIFF
--- a/io.github.SVGStationPlanEditor/linglong.yaml
+++ b/io.github.SVGStationPlanEditor/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.SVGStationPlanEditor
+  name: SVGStationPlanEditor
+  version: 1.0.0
+  kind: app
+  description: |
+    A simple editor for railway station plan in SVG format
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/gfgit/SVGStationPlanEditor.git
+  commit: 0614fb5f8c57eb82ab7d59634f48e6a9fc328053
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.SVGStationPlanEditor/patches/0001-install.patch
+++ b/io.github.SVGStationPlanEditor/patches/0001-install.patch
@@ -1,0 +1,40 @@
+From 99b70a24ee9f4085d33299a5a8d8aec9ea1b04a5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 6 Nov 2023 15:08:46 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt              | 2 +-
+ build_dir/sspviewer.desktop | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+ create mode 100644 build_dir/sspviewer.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b7aed6..c5e80e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,5 +113,5 @@ if(WIN32)
+             ")
+     endif()
+ endif()
+-
++install(PROGRAMS ${CMAKE_BINARY_DIR}/sspviewer.desktop DESTINATION share/applications)
+ ## Install end ##
+diff --git a/build_dir/sspviewer.desktop b/build_dir/sspviewer.desktop
+new file mode 100644
+index 0000000..c12f48d
+--- /dev/null
++++ b/build_dir/sspviewer.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=sspviewer
++Name=sspviewer
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A simple editor for railway station plan in SVG format

Log: add software name--SVGStationPlanEditor
![SVGStationPlanEditor](https://github.com/linuxdeepin/linglong-hub/assets/147463620/796f9b0a-0a29-47dd-bc69-23b98ab2f213)
