### PR TITLE
build: add fusepdf

### DIFF
--- a/io.github.fusepdf/linglong.yaml
+++ b/io.github.fusepdf/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.fusepdf
+  name: fusepdf
+  version: 2.2.0
+  kind: app
+  description: |
+    FusePDF is a simple cross-platform application used for merging, splitting and exporting PDF pages and documents.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/nettstudio/fusepdf.git
+  commit: c89cec7008c87c4daad2c0de1d49b116a083c2f9
+
+build:
+  kind: qmake


### PR DESCRIPTION
FusePDF is a simple cross-platform application used for merging, splitting and exporting PDF pages and documents.

Log: add software name--fusepdf
![fusepdf](https://github.com/linuxdeepin/linglong-hub/assets/147463620/8e5ff3cd-3868-4ff4-9515-8b3e0fe2d1fd)
