### PR TITLE
build: add app MRichTextEditor

### DIFF
--- a/io.github.MRichTextEditor/linglong.yaml
+++ b/io.github.MRichTextEditor/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.MRichTextEditor
+  name: MRichTextEditor
+  version: 1.0.0
+  kind: app
+  description: |
+    A simple Qt rich-text editor widget, easy to use in any Qt project.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+
+source:
+  kind: git
+  url: https://github.com/Anchakor/MRichTextEditor.git
+  commit: d7334459f6c112de8e4697f480f53b77064949ba
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+
+      

--- a/io.github.MRichTextEditor/patches/0001-install.patch
+++ b/io.github.MRichTextEditor/patches/0001-install.patch
@@ -1,0 +1,49 @@
+From b51afb7644c33a7e777448d12641660d6dede93c Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Wed, 8 Nov 2023 12:04:55 +0800
+Subject: [install.patch_] install
+
+---
+ MRichTextEditor.desktop |  7 +++++++
+ MRichTextEditor.pro     | 13 +++++++++++++
+ 2 files changed, 20 insertions(+)
+ create mode 100644 MRichTextEditor.desktop
+
+diff --git a/MRichTextEditor.desktop b/MRichTextEditor.desktop
+new file mode 100644
+index 0000000..5cd17c2
+--- /dev/null
++++ b/MRichTextEditor.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Exec=MRichTextEdit
++GenericName=MRichTextEdit
++Hidden=false
++Name=MRichTextEdit
++StartupNotify=false
++Type=Application
+diff --git a/MRichTextEditor.pro b/MRichTextEditor.pro
+index 6b93bda..bd2c0d4 100644
+--- a/MRichTextEditor.pro
++++ b/MRichTextEditor.pro
+@@ -13,3 +13,16 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+ HEADERS += mrichtextedit.h mtextedit.h
+ FORMS += mrichtextedit.ui
+ SOURCES += mrichtextedit.cpp mtextedit.cpp test.cpp
++
++unix: {
++
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = MRichTextEditor.desktop
++INSTALLS += unix_desktop
++
++
++}
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A simple Qt rich-text editor widget, easy to use in any Qt project.

Logs: add app name--MRichTextEditor
![1b913b8daf23f56800e9ce9c9d14954](https://github.com/linuxdeepin/linglong-hub/assets/147809353/3cf23916-0a65-4b4b-95d7-80803d7a6161)
