### PR TITLE
build: add HTYPaint_Qt

### DIFF
--- a/io.github.HTYPaint_Qt/linglong.yaml
+++ b/io.github.HTYPaint_Qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.HTYPaint_Qt
+  name: HTYPaint_Qt
+  version: 0.0.1
+  kind: app
+  description: |
+    Baton is a code editor for C++ Design document:
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/sonichy/HTYPaint_Qt.git"
+  commit: 52aebc300465478fea5449266af77b44729dc5a5
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.HTYPaint_Qt/patches/0001-install.patch
+++ b/io.github.HTYPaint_Qt/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 8ff6a6586b62c2b8b561864ff9e4232c336346c0 Mon Sep 17 00:00:00 2001
+From: xwqlikepsl <2242484264@qq.com>
+Date: Wed, 8 Nov 2023 12:13:47 +0800
+Subject: [install.patch_] install
+
+---
+ HTYPaint.desktop |  6 ++++++
+ HTYPaint.pro     | 11 ++++++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 HTYPaint.desktop
+
+diff --git a/HTYPaint.desktop b/HTYPaint.desktop
+new file mode 100644
+index 0000000..1e4f8fc
+--- /dev/null
++++ b/HTYPaint.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=HTYPaint
++Exec=HTYPaint
++Terminal=false
+\ No newline at end of file
+diff --git a/HTYPaint.pro b/HTYPaint.pro
+index d2e80c5..65a3245 100644
+--- a/HTYPaint.pro
++++ b/HTYPaint.pro
+@@ -17,4 +17,13 @@ FORMS    += mainwindow.ui
+ RESOURCES += \
+     res.qrc
+ 
+-RC_FILE = res.rc
+\ No newline at end of file
++RC_FILE = res.rc
++
++unix: {
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = HTYPaint.desktop
++INSTALLS += unix_desktop
++}
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Finish build HTYPaint_Qt for ll-build

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/110f943e-2cc1-414e-89d1-3bd5ea03762e)


Log: 完成App:HTYPaint_Qt的编译