### PR TITLE
add Qt monkey

### DIFF
--- a/io.github.qt_monkey/linglong.yaml
+++ b/io.github.qt_monkey/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.qt_monkey
+  name: qt_monkey
+  version: 1.0.0
+  kind: app
+  description: |
+    Qt Monkey is a tool to automate testing of Qt-based applications (widgets only). It automates creation/modification and running of the tests. Tests are written in Javascript (Qt supported dialect). 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/Dushistov/qt_monkey.git
+  commit: f51e35cd9d38a18d7f331f0114fc23d88b630c28
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake
+
+      

--- a/io.github.qt_monkey/patches/0001-install.patch
+++ b/io.github.qt_monkey/patches/0001-install.patch
@@ -1,0 +1,41 @@
+From fda13ce887017f271fc77c2f522bfbd111a06807 Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Wed, 8 Nov 2023 14:40:55 +0800
+Subject: [install.patch_] install
+
+---
+ CMakeLists.txt   | 2 ++
+ qtmonkey.desktop | 7 +++++++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 qtmonkey.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 71f1f6c..e750cb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,6 +143,8 @@ endif ()
+ file(GLOB QT_MONKEY_HEADERS ${qt_monkey_SOURCE_DIR}/*.hpp)
+ install(FILES ${QT_MONKEY_HEADERS} DESTINATION include/qt_monkey)
+ 
++install(FILES qtmonkey.desktop DESTINATION share/applications)
++
+ install(TARGETS qtmonkey_agent DESTINATION lib)
+ 
+ install(TARGETS qtmonkey_app qtmonkey_gui
+diff --git a/qtmonkey.desktop b/qtmonkey.desktop
+new file mode 100644
+index 0000000..e6ba893
+--- /dev/null
++++ b/qtmonkey.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Exec=qtmonkey_gui
++GenericName=qtmonkey
++Hidden=false
++Name=qtmonkey
++StartupNotify=false
++Type=Application
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Qt Monkey is a tool to automate testing of Qt-based applications (widgets only). It automates creation/modification and running of the tests. Tests are written in Javascript (Qt supported dialect). 

Logs: add app name--qt_monkey
![bfab030f396d7f384cde386293fd5bd](https://github.com/linuxdeepin/linglong-hub/assets/147809353/7805da33-33f0-4481-95f4-b0db79fe246d)
