### PR TITLE
build: add app DustRacing2D

### DIFF
--- a/io.github.DustRacing2D/linglong.yaml
+++ b/io.github.DustRacing2D/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.DustRacing2D
+  name: DustRacing2D
+  version: 2.1.1
+  kind: app
+  description: |
+    Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.  
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+
+source:
+  kind: git
+  url: https://github.com/juzzlin/DustRacing2D.git
+  commit: 2c00334135aa004213758a0121a23a872660aa79
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake
+
+      

--- a/io.github.DustRacing2D/patches/0001-install.patch
+++ b/io.github.DustRacing2D/patches/0001-install.patch
@@ -1,0 +1,40 @@
+From 88e626318b63f97718f35a83312c3ede440965df Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Wed, 8 Nov 2023 17:21:20 +0800
+Subject: [install.patch_] install
+
+---
+ CMakeLists.txt | 5 +++++
+ Dust.desktop   | 7 +++++++
+ 2 files changed, 12 insertions(+)
+ create mode 100644 Dust.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c4dcbaf..1a62f438 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -195,3 +195,8 @@ resolve_install_paths()
+ 
+ add_subdirectory(src/editor)
+ add_subdirectory(src/game)
++
++
++install(TARGETS dustrac-editor DESTINATION bin)
++install(FILES Dust.desktop DESTINATION share/applications)
++
+diff --git a/Dust.desktop b/Dust.desktop
+new file mode 100644
+index 00000000..e945d43a
+--- /dev/null
++++ b/Dust.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Exec=dustrac-editor
++GenericName=dustrac-editor
++Hidden=false
++Name=dustrac-editor
++StartupNotify=false
++Type=Application
+-- 
+2.33.1
+


### PR DESCRIPTION
Dust Racing 2D (Dustrac) is a tile-based, cross-platform 2D racing game written in Qt (C++) and OpenGL.

Logs: add app name--DustRacing2D
![image](https://github.com/linuxdeepin/linglong-hub/assets/147809353/ee704ed7-0354-42a7-90bd-ecb2ab0ed2de)
