### PR TITLE
build: add Text-Editor-With-Qt

### DIFF
--- a/io.github.Text-Editor-With-Qt/linglong.yaml
+++ b/io.github.Text-Editor-With-Qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.Text-Editor-With-Qt
+  name: Text-Editor-With-Qt
+  version: 0.0.1
+  kind: app
+  description: |
+    The project aims to design a simple text editor that can perform basic text processing with some advanced features.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/aspxcor/Text-Editor-With-Qt.git
+  commit: 10b5168d3123fd50d4636933655318ee907f264a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.Text-Editor-With-Qt/patches/0001-install.patch
+++ b/io.github.Text-Editor-With-Qt/patches/0001-install.patch
@@ -1,0 +1,45 @@
+From 080b1e6f022880e7f1597bbc5acaeebb197ad61e Mon Sep 17 00:00:00 2001
+From: xwqlikepsl <2242484264@qq.com>
+Date: Fri, 10 Nov 2023 10:12:18 +0800
+Subject: [install.patch_] install
+
+---
+ Editor.desktop |  6 ++++++
+ Editor.pro     | 10 ++++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 Editor.desktop
+
+diff --git a/Editor.desktop b/Editor.desktop
+new file mode 100644
+index 0000000..506592f
+--- /dev/null
++++ b/Editor.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=Editor
++Exec=Editor
++Terminal=false
+\ No newline at end of file
+diff --git a/Editor.pro b/Editor.pro
+index c8f5e7f..d49385a 100644
+--- a/Editor.pro
++++ b/Editor.pro
+@@ -48,3 +48,13 @@ RESOURCES += \
+     myresorces.qrc
+ 
+ RC_FILE += rsc/Editor.rc
++
++unix: {
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = Editor.desktop
++INSTALLS += unix_desktop
++}
++
+-- 
+2.33.1
+


### PR DESCRIPTION
Finish build Text-Editor-With-Qt for ll-build

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/8f0e20eb-dac8-4d11-b6a9-d273d73206a1)


Log: 完成App:Text-Editor-With-Qt的编译