### PR TITLE
build: add app qtmind

### DIFF
--- a/io.github.qtmind/linglong.yaml
+++ b/io.github.qtmind/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.qtmind
+  name: qtmind
+  version: 0.8.5
+  kind: app
+  description: |
+    QtMind is a Mastermid game in Qt, with built in solver. Most of the major solving algorithms are integrated in QtMind.  
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+
+source:
+  kind: git
+  url: https://github.com/mehdioa/qtmind.git
+  commit: 6969b810118e1f50fc5465fa09a754d1501618b5
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+
+      

--- a/io.github.qtmind/patches/0001-install.patch
+++ b/io.github.qtmind/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From 93bc21642ac1c35dc7f28c4f24f19aa9a8612d55 Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Fri, 10 Nov 2023 16:11:27 +0800
+Subject: [install.patch_] install
+
+---
+ qtmind.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qtmind.pro b/qtmind.pro
+index 1f6779c..5eee720 100644
+--- a/qtmind.pro
++++ b/qtmind.pro
+@@ -106,7 +106,7 @@ OTHER_FILES += \
+ 	src/src.qbs
+ 
+ unix:!macx { # installation on Unix-ish platforms
+-	isEmpty(INSTALL_PREFIX):INSTALL_PREFIX = /usr
++	isEmpty(INSTALL_PREFIX):INSTALL_PREFIX = $${PREFIX}
+ 	isEmpty(BIN_DIR):BIN_DIR = $$INSTALL_PREFIX/bin
+ 	isEmpty(DATA_DIR):DATA_DIR = $$INSTALL_PREFIX/share
+ 	isEmpty(ICON_DIR):ICON_DIR = $$DATA_DIR/pixmaps
+-- 
+2.33.1
+


### PR DESCRIPTION
QtMind is a Mastermid game in Qt, with built in solver. Most of the major solving algorithms are integrated in QtMind.

Logs: add app name--qtmind
![99dd2fb93443feef2310e58ccdf7b89](https://github.com/linuxdeepin/linglong-hub/assets/147809353/95835ca2-b6be-4f0f-b654-3bb0599c4f66)
