### PR TITLE
build: add app screengrab

### DIFF
--- a/io.github.screengrab/linglong.yaml
+++ b/io.github.screengrab/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.screengrab
+  name: screengrab
+  version: 2.0.0
+  kind: app
+  description: |
+    Crossplatform tool for fast making screenshots.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: kwindowsystem/5.54.0
+  - id: lxqt-build-tools/0.8.0
+
+
+source:
+  kind: git
+  url: https://github.com/lxqt/screengrab.git
+  commit: 5aee4069558a76b5d383ced0200ccc14022ab3ff
+  patch: patches/fix-001.patch
+
+build:
+  kind: cmake

--- a/io.github.screengrab/patches/fix-001.patch
+++ b/io.github.screengrab/patches/fix-001.patch
@@ -1,0 +1,14 @@
+--- ../CMakeLists.txt	2023-11-07 15:38:17.511756000 +0800
++++ ../CMakeLists.txt	2023-11-07 17:41:21.115235331 +0800
+@@ -66,8 +66,10 @@
+ 
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Woverloaded-virtual -Wall -Wextra")
+ 
++
+ set(SG_LIBDIR "${CMAKE_INSTALL_LIBDIR}/screengrab")
+-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${SG_LIBDIR}")
++# set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${SG_LIBDIR}")
++set(CMAKE_INSTALL_RPATH "${SG_LIBDIR}")
+ message(STATUS "Library path: ${CMAKE_INSTALL_RPATH}")
+ 
+ # Although the names, LXQtTranslateTs and LXQtTranslateDesktop, they don't


### PR DESCRIPTION
用于创建屏幕截图的应用程序。 ScreenGrab 使用 Qt 框架，因此它独立于任何桌面环境。

Log: finish app screengrab.

![40307a4dc02a5cda7ebea1cf4b5c60db](https://github.com/linuxdeepin/linglong-hub/assets/115330610/3cff3d94-8c6d-4228-95d4-387b863f6323)
