### PR TITLE
build: add app LEDStripDesigner

### DIFF
--- a/io.github.LEDStripDesigner/linglong.yaml
+++ b/io.github.LEDStripDesigner/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.LEDStripDesigner
+  name: LEDStripDesigner
+  version: 1.0.0
+  kind: app
+  description: |
+    A software to design a LED Strip with animations for an AVR Arduino ATMega328P.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/Tropby/LEDStripDesigner.git
+  commit: 0477c398517e707c06d503cf9c82fe185d012178
+  patch: patches/fix-001.patch
+
+build:
+  kind: qmake
+

--- a/io.github.LEDStripDesigner/patches/fix-001.patch
+++ b/io.github.LEDStripDesigner/patches/fix-001.patch
@@ -1,0 +1,23 @@
+--- ../LEDStripDesigner.pro	2023-11-09 20:46:07.471038000 +0800
++++ ../LEDStripDesigner.pro	2023-11-09 20:49:32.783655198 +0800
+@@ -33,3 +33,20 @@
+ 
+ RESOURCES += \
+     src/res.qrc
++
++DESKTOP_FILE = ./LEDStripDesigner.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=LEDStripDesigner' >> $$DESKTOP_FILE")
++system("echo 'Comment=LEDStripDesigner, a tool.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$PREFIX/bin/LEDStripDesigner' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION
用于为 AVR Arduino ATMega328P 设计带动画的 LED 灯条 WS1228B 的软件。动画保存在 SD 卡上或通过 UART 发送到微处理器。 资源.

Log: finish app LEDStripDesigger.


![828ecf257e0a548ff6fcdd5b266fbd6f](https://github.com/linuxdeepin/linglong-hub/assets/115330610/9d57d368-c21b-4251-bb44-3b58b49be66d)

