### PR TITLE
build: add app socket-spy

### DIFF
--- a/io.github.socket-spy/linglong.yaml
+++ b/io.github.socket-spy/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.socket-spy
+  name: socket-spy
+  version: 1.0.0
+  kind: app
+  description: |
+    A Graphical desktop app to spy sockets.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/realbardia/socket-spy.git
+  commit: 0ff89df017a86504659452cde438b212e63d5076
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.socket-spy/patches/fix-001.patch
+++ b/io.github.socket-spy/patches/fix-001.patch
@@ -1,0 +1,24 @@
+--- ../SocketSpy.pro	2023-11-09 14:12:22.867091000 +0800
++++ ../SocketSpy.pro	2023-11-09 14:23:25.958053180 +0800
+@@ -24,3 +24,21 @@
+ 
+ RESOURCES += \
+     resource.qrc
++
++
++DESKTOP_FILE = ./SocketSpy.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=SocketSpy' >> $$DESKTOP_FILE")
++system("echo 'Comment=SocketSpy, a tool for calculate.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$PREFIX/bin/SocketSpy' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++qnx: target.path = /tmp/$${TARGET}/bin
++else: unix:!android: target.path = $${PREFIX}/bin
++!isEmpty(target.path): INSTALLS += target


### PR DESCRIPTION
用于监视套接字的图形桌面应用程序.

Log: finish app socket-spy.

![289d5d52358f5b6f043475fa31b270fa](https://github.com/linuxdeepin/linglong-hub/assets/115330610/26506068-7864-40f5-8ab2-2c7e2c25280a)
