### PR TITLE
build: add app cute-light-text-previewer

### DIFF
--- a/io.github.cute-light-text-previewer/linglong.yaml
+++ b/io.github.cute-light-text-previewer/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.cute-light-text-previewer
+  name: cute-light-text-previewer
+  version: 2.2.0
+  kind: app
+  description: |
+    A cross-platform application that opens and translates large text files instantly.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/enjoysoftware/cute-light-text-previewer.git
+  commit: f776d46488db667c9aada06129040c0e3221e5fe
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake

--- a/io.github.cute-light-text-previewer/patches/fix-001.patch
+++ b/io.github.cute-light-text-previewer/patches/fix-001.patch
@@ -1,0 +1,21 @@
+--- ../cute-light-text-previewer.pro	2023-11-09 19:17:58.396574000 +0800
++++ ../cute-light-text-previewer.pro	2023-11-09 19:28:59.974655740 +0800
+@@ -8,7 +8,7 @@
+ # any Qt feature that has been marked deprecated (the exact warnings
+ # depend on your compiler). Please consult the documentation of the
+ # deprecated API in order to know how to port your code away from it.
+-DEFINES += QT_DEPRECATED_WARNINGS WITH_DARKSTYLE
++DEFINES += QT_DEPRECATED_WARNINGS #WITH_DARKSTYLE
+ 
+ # You can also make your code fail to compile if it uses deprecated APIs.
+ # In order to do so, uncomment the following line.
+@@ -38,8 +38,7 @@
+ RESOURCES += \
+     files.qrc \
+     icons.qrc \
+-    theme.qrc \
+-    translations.qrc
++    translations.qrc  # theme.qrc \
+ TRANSLATIONS = \
+     translations/text-previewer_ja_JP.ts
+ #LUPDATE = $$[QT_INSTALL_BINS]/lupdate -locations absolute -no-obsolete


### PR DESCRIPTION
一个跨平台应用程序，可以立即打开和翻译大型文本文件。

Log: finish app cute-light-text-previewer.

![dcd6992cfae81fe22ca0933ace5adf11](https://github.com/linuxdeepin/linglong-hub/assets/115330610/ba0dd2a1-5278-4211-be75-0736c4408261)
