### PR TITLE
build: add app speedcrunch

### DIFF
--- a/io.github.speedcrunch/linglong.yaml
+++ b/io.github.speedcrunch/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.speedcrunch
+  name: speedcrunch
+  version: 0.12.0
+  kind: app
+  description: |
+    SpeedCrunch is a high-precision scientific calculator. It features a syntax-highlighted scrollable display and is designed to be fully used via keyboard. Some distinctive features are auto-completion of functions and variables, a formula book, and quick insertion of constants from various fields of knowledge. It is available for Windows, OS X, and Linux in a number of languages.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qttools
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/liudonghua123/speedcrunch.git
+  commit: 74756f3438149c01e9edc3259b0f411fa319a22f
+
+build:
+  kind: cmake
+  manual :
+    configure: |
+      cmake -B ${build_dir} ${conf_args} ${extra_args} ./src


### PR DESCRIPTION
SpeedCrunch是高精度的科学计算器。它具有语法高的可滚动显示屏，设计为通过键盘充分使用。

Log: finish app speedcrunch.

![24244c70d28bb9f25a92ef35ea06b4ef](https://github.com/linuxdeepin/linglong-hub/assets/115330610/c49dc7ed-615d-4fe7-8c8a-3ce4b0bdf865)
