### PR TITLE
build: add app git-chart-drawer

### DIFF
--- a/io.github.git-chart-drawer/linglong.yaml
+++ b/io.github.git-chart-drawer/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.git-chart-drawer
+  name: git-chart-drawer
+  version: 1.0.0
+  kind: app
+  description: |
+    Draw charts from your Git repository using Qt and QtCharts.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtcharts
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/realbardia/git-chart-drawer.git
+  commit: 14c5d911148e4dc3116448b091d3f728fe663274
+
+build:
+  kind: qmake


### PR DESCRIPTION
使用QT和QTCHARTS从您的GIT存储库中绘制图表.

Log: finish app git-chart-drawer.

![d9ba42aefffc5f6c49d7c61590d4ae41](https://github.com/linuxdeepin/linglong-hub/assets/115330610/bb82dedf-4060-48bf-b7a8-5258e512938f)
