### PR TITLE
build: add app fitbit-activities-chart

### DIFF
--- a/io.github.fitbit-activities-chart/linglong.yaml
+++ b/io.github.fitbit-activities-chart/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.fitbit-activities-chart
+  name: fitbit-activities-chart
+  version: 1.0.0
+  kind: app
+  description: |
+    Fitbit Activities Chart.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtcharts
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/realbardia/fitbit-activities-chart.git
+  commit: 0d281810b0c7607853706cd2829c5d20943b9f99
+  patch: patches/fix-001.patch
+
+build:
+  kind: qmake

--- a/io.github.fitbit-activities-chart/patches/fix-001.patch
+++ b/io.github.fitbit-activities-chart/patches/fix-001.patch
@@ -1,0 +1,25 @@
+--- ../FitbitActivitiesChart.pro	2023-11-09 17:06:28.319560000 +0800
++++ ../FitbitActivitiesChart.pro	2023-11-09 17:13:52.081143811 +0800
+@@ -18,3 +18,22 @@
+ 
+ RESOURCES += \
+     resource.qrc
++
++
++DESKTOP_FILE = ./FitbitActivitiesChart.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=FitbitActivitiesChart' >> $$DESKTOP_FILE")
++system("echo 'Comment=FitbitActivitiesChart, a tool.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$PREFIX/bin/FitbitActivitiesChart' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++


### PR DESCRIPTION
Fitbit活动图表，将csv文件导入，可以展示对应的图表。

Log: finish app fitbit-activities-chart.

![6c8ae05064bb7663fa83855d2935739e](https://github.com/linuxdeepin/linglong-hub/assets/115330610/fb83b681-9251-4d9c-85c3-6b8afd3daf89)
