### PR TITLE
build: add app corewar2

### DIFF
--- a/io.github.corewar2/linglong.yaml
+++ b/io.github.corewar2/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.corewar2
+  name: corewar2
+  version: 0.0.1
+  kind: app
+  description: |
+    Corewar2 is a very simple Corewar clone, written in C++ with Qt. The language used was created by myself for this purpose and named CWA (for CoreWar Assembly). It's a simple assembly language, with 7 instructions.  
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/remram44/corewar2.git
+  commit: 9448c18901909c49d05ce7fdb56ef9dd58122709
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+
+      

--- a/io.github.corewar2/patches/0001-install.patch
+++ b/io.github.corewar2/patches/0001-install.patch
@@ -1,0 +1,52 @@
+From a6481aee48c3d8d1532002aa8925106520fdd109 Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Mon, 13 Nov 2023 18:22:45 +0800
+Subject: [install.patch_] install
+
+---
+ corewar2.desktop |  7 +++++++
+ corewar2.pro     | 15 +++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 corewar2.desktop
+
+diff --git a/corewar2.desktop b/corewar2.desktop
+new file mode 100644
+index 0000000..beed36f
+--- /dev/null
++++ b/corewar2.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Exec=corewar2
++GenericName=corewar2
++Hidden=false
++Name=corewar2
++StartupNotify=false
++Type=Application
+\ No newline at end of file
+diff --git a/corewar2.pro b/corewar2.pro
+index 9065fe6..f2130eb 100644
+--- a/corewar2.pro
++++ b/corewar2.pro
+@@ -19,3 +19,18 @@ SOURCES += Corewar.cpp Program.cpp Field.cpp
+ 
+ TRANSLATIONS = corewar2_fr.ts
+ CODECFORTR = UTF-8
++
++
++unix: {
++
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = corewar2.desktop
++INSTALLS += unix_desktop
++
++
++
++}
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Corewar2 is a very simple Corewar clone, written in C++ with Qt. The language used was created by myself for this purpose and named CWA (for CoreWar Assembly). It's a simple assembly language, with 7 instructions.

Logs: add app name--corewar2
![d476784837757a1391e859503b29669](https://github.com/linuxdeepin/linglong-hub/assets/147809353/1e0478f4-0e67-44df-9bc9-76e74f0ffc92)
