### PR TITLE
build:add uPDF2

### DIFF
--- a/io.github.uPDF2/linglong.yaml
+++ b/io.github.uPDF2/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.uPDF2
+  name: uPDF2
+  version: 2.3.0
+  kind: app
+  description: |
+    This software is licensed under Gnu General Public License Version 3. Please look at the COPYING file for further details.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/turgu1/uPDF2.git
+  commit: caf000d3949674d7ea0844b45282f578c1ffdaa8
+  patch: patches/0001-fix-install.patch 
+
+build:
+  kind: qmake
+

--- a/io.github.uPDF2/patches/0001-fix-install.patch
+++ b/io.github.uPDF2/patches/0001-fix-install.patch
@@ -1,0 +1,45 @@
+From 47549bc5b30a08166aa9a17845618bc95a1e04e1 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Wed, 15 Nov 2023 11:31:15 +0800
+Subject: [PATCH] fix-install
+
+---
+ uPDF2.desktop | 8 ++++++++
+ uPDF2.pro     | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 uPDF2.desktop
+
+diff --git a/uPDF2.desktop b/uPDF2.desktop
+new file mode 100644
+index 0000000..2bf6a2b
+--- /dev/null
++++ b/uPDF2.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=tool;Qt;
++Exec=uPDF2
++Name=uPDF2
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/uPDF2.pro b/uPDF2.pro
+index 14ce647..40c9f52 100644
+--- a/uPDF2.pro
++++ b/uPDF2.pro
+@@ -101,3 +101,11 @@ unix|win32: LIBS += -lpoppler -llzo2
+ QT          += widgets
+ CONFIG      += plugin
+ #TEMPLATE    = lib
++
++#install role
++BINDIR  = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = uPDF2.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION

![image](https://github.com/linuxdeepin/linglong-hub/assets/84424520/4899cd58-1861-4415-b32e-66561d0f001f)

This software is licensed under Gnu General Public License Version 3. Please look at the COPYING file for further details.

log: add software--uPDF2