### PR TITLE
build: add KNetStats

### DIFF
--- a/io.github.KNetStats/linglong.yaml
+++ b/io.github.KNetStats/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.KNetStats
+  name: KNetStats
+  version: 2.0.0
+  kind: app
+  description: |
+    A simple network interface and statistics viewer for Linux.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: kwidgetsaddons
+    version: 5.90.0
+
+source:
+  kind: git
+  url: https://github.com/telans/KNetStats.git
+  commit: 3818748bb012275d699fd43614c3294fecf801c4
+
+build:
+  kind: cmake


### PR DESCRIPTION
Simple network interface and statistics viewer

Log: add software name--KNetStats
![KNetStats](https://github.com/linuxdeepin/linglong-hub/assets/147463620/3c87d958-cee5-432e-bc50-0a4c63533055)
