### PR TITLE
build: add cassolette

### DIFF
--- a/io.github.cassolette/linglong.yaml
+++ b/io.github.cassolette/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.cassolette
+  name: cassolette
+  version: 1.0.0
+  kind: app
+  description: |
+    Cassolette is a free and multi-platform utility software to help analysing and converting the encoding of text files.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/fougue/cassolette.git
+  commit: 0aa8449f5a675f7ce3c897318c4872ed104e2835
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.cassolette/patches/0001-install.patch
+++ b/io.github.cassolette/patches/0001-install.patch
@@ -1,0 +1,47 @@
+From 1601f537736aa237c3fc31b4b34c3f502145a364 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 14 Nov 2023 19:32:43 +0800
+Subject: [PATCH] install
+
+---
+ cassolette.desktop | 8 ++++++++
+ cassolette.pro     | 7 ++++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+ create mode 100644 cassolette.desktop
+
+diff --git a/cassolette.desktop b/cassolette.desktop
+new file mode 100644
+index 0000000..2f1fd56
+--- /dev/null
++++ b/cassolette.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=cassolette
++Name=cassolette
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/cassolette.pro b/cassolette.pro
+index 7415812..feb3285 100644
+--- a/cassolette.pro
++++ b/cassolette.pro
+@@ -67,7 +67,12 @@ OTHER_FILES += \
+     deploy/windows/setup.iss \
+     $$QMAKE_SUBSTITUTES
+ 
+-
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =cassolette.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+ # Mozilla Universal Character Set Detector library
+ include(src/3rdparty/ucsd/ucsd.pri)
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
Cassolette is a free and multi-platform utility software to help analysing and converting the encoding of text files.

Log: add software name--cassolette
![cassolette](https://github.com/linuxdeepin/linglong-hub/assets/147463620/12fb665a-66b4-461d-90ef-b9c907af531f)
