### PR TITLE
build: add qt5-action-editor

### DIFF
--- a/io.github.qt5-action-editor/linglong.yaml
+++ b/io.github.qt5-action-editor/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qt5-action-editor
+  name: qt5-action-editor
+  version: 0.0.1
+  kind: app
+  description: |
+    A port of qq14-actioneditor from Qt Quarterly to Qt5
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/eteran/qt5-action-editor.git
+  commit: ebc37abeadf4cd96d96f5a7cf0a690bff0e4e331
+  patch: patches/0001-fix-install.patch 
+
+build:
+  kind: cmake

--- a/io.github.qt5-action-editor/patches/0001-fix-install.patch
+++ b/io.github.qt5-action-editor/patches/0001-fix-install.patch
@@ -1,0 +1,33 @@
+From d64fee136198bca4672ea8ebe76da56637018ef5 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Wed, 15 Nov 2023 12:44:05 +0800
+Subject: [PATCH] fix-install
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e64961e..53c186c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,3 +23,16 @@ target_link_libraries(qt5-action-editor
+ 	Qt5::Gui
+ 	Qt5::PrintSupport
+ )
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=qt5-action-editor.desktop
++Exec=qt5-action-editor
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/qt5-action-editor.desktop "${DESKTOP_FILE_CONTENT}")
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/qt5-action-editor.desktop DESTINATION share/applications)
++install(TARGETS qt5-action-editor DESTINATION bin)
+-- 
+2.33.1
+


### PR DESCRIPTION

![image](https://github.com/linuxdeepin/linglong-hub/assets/84424520/b292c12d-74b0-4865-8181-d0f515445e8f)

A port of qq14-actioneditor from Qt Quarterly to Qt5.

log: add software--qt5-action-editor