### PR TITLE
build: add NotePadNext

### DIFF
--- a/io.github.NotePadNext/linglong.yaml
+++ b/io.github.NotePadNext/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.NotePadNext
+  name: NotePadNext
+  version: 0.6.4
+  kind: app
+  description: |
+    A cross-platform, reimplementation of Notepad++
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dail8859/NotepadNext.git
+  commit: ccbd3484862ec1f833af428a8050260fd1511566
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install


### PR DESCRIPTION
A cross-platform, reimplementation of Notepad++

Log: add software name--NotePadNext
![NotePadNext](https://github.com/linuxdeepin/linglong-hub/assets/147463620/524a3d83-0286-4b6d-9bd7-42d9629e8038)
