### PR TITLE
build: add CloudLogCatQt

### DIFF
--- a/io.github.CloudLogCatQt/linglong.yaml
+++ b/io.github.CloudLogCatQt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.CloudLogCatQt
+  name: CloudLogCatQt
+  version: 1.0.0
+  kind: app
+  description: |
+    Qt app that can be compiled on Linux, Windows or Mac for providing CAT support for Cloudlog
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/myzinsky/CloudLogCatQt.git
+  commit: 7f954a1f717c7e0ffd8e5b882c54e25981df1d4a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.CloudLogCatQt/patches/0001-install.patch
+++ b/io.github.CloudLogCatQt/patches/0001-install.patch
@@ -1,0 +1,47 @@
+From 8361ff10d396c2b7edaad37df70c2522a746466f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 15 Nov 2023 12:27:14 +0800
+Subject: [PATCH] install
+
+---
+ CloudLogCatQt.desktop | 8 ++++++++
+ CloudLogCatQt.pro     | 9 ++++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 CloudLogCatQt.desktop
+
+diff --git a/CloudLogCatQt.desktop b/CloudLogCatQt.desktop
+new file mode 100644
+index 0000000..01460dd
+--- /dev/null
++++ b/CloudLogCatQt.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=CloudLogCatQt
++Name=CloudLogCatQt
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/CloudLogCatQt.pro b/CloudLogCatQt.pro
+index 189ff53..25cbf58 100644
+--- a/CloudLogCatQt.pro
++++ b/CloudLogCatQt.pro
+@@ -56,5 +56,12 @@ FORMS += cloudlogcatqt.ui
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =CloudLogCatQt.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Qt app that can be compiled on Linux, Windows or Mac for providing CAT support for Cloudlog

Log: add software name--CloudLogCatQt
![CloudLogCatQtpng](https://github.com/linuxdeepin/linglong-hub/assets/147463620/95ea33ea-e1e4-44ab-b35a-bf8e67e583a0)
