### PR TITLE
build: add chmod-generator

### DIFF
--- a/io.github.chmod-generator/linglong.yaml
+++ b/io.github.chmod-generator/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.chmod-generator
+  name: chmod-generator
+  version: 1.0.0
+  kind: app
+  description: |
+    This is a GUI for chmod and chown that I made when I was younger, while learning C++ and Qt
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/CodingKoopa/chmod-generator.git
+  commit: 198613e52b7a0f7a78adca79aa9dcfd0e9748f99
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.chmod-generator/patches/0001-install.patch
+++ b/io.github.chmod-generator/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From d206ea85e917981268d25f3b63472e52334f1bf4 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 15 Nov 2023 18:23:22 +0800
+Subject: [PATCH] install
+
+---
+ CHMOD.desktop | 8 ++++++++
+ CHMOD.pro     | 6 ++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 CHMOD.desktop
+
+diff --git a/CHMOD.desktop b/CHMOD.desktop
+new file mode 100644
+index 0000000..83ba2fe
+--- /dev/null
++++ b/CHMOD.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=CHMOD
++Name=CHMOD
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/CHMOD.pro b/CHMOD.pro
+index 07a927a..94d7bb1 100644
+--- a/CHMOD.pro
++++ b/CHMOD.pro
+@@ -28,3 +28,9 @@ HEADERS  += dialog.h \
+ 
+ FORMS    += dialog.ui \
+     symbolic.ui
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =CHMOD.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
This is a GUI for chmod and chown that I made when I was younger, while learning C++ and Qt.

Log: add software name--chmod-generator
![chmod-generator](https://github.com/linuxdeepin/linglong-hub/assets/147463620/843a7832-96f5-4b44-9260-09d07889a7ed)
