### PR TITLE
build: add QDebugToTxtLog

### DIFF
--- a/io.github.QDebugToTxtLog/linglong.yaml
+++ b/io.github.QDebugToTxtLog/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.QDebugToTxtLog
+  name: QDebugToTxtLog
+  version: 0.0.1
+  kind: app
+  description: |
+    convert QDebug message to txt format log file.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/liulangx/QDebugToTxtLog.git"
+  commit: 56aadc2bd14fa8a1de4cd1f69b1fac8b99226661
+  patch:
+    - patches/add-desktop.patch
+
+build:
+  kind: qmake

--- a/io.github.QDebugToTxtLog/patches/add-desktop.patch
+++ b/io.github.QDebugToTxtLog/patches/add-desktop.patch
@@ -1,0 +1,26 @@
+diff --git a/qDebugToTxtLog.desktop b/qDebugToTxtLog.desktop
+new file mode 100644
+index 0000000..85726ba
+--- /dev/null
++++ b/qDebugToTxtLog.desktop
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Type=Application
++Name=qDebug To Txt Log
++Exec=qDebugToTxtLog %f
+diff --git a/qDebugToTxtLog.pro b/qDebugToTxtLog.pro
+index c02c71d..1eec086 100644
+--- a/qDebugToTxtLog.pro
++++ b/qDebugToTxtLog.pro
+@@ -40,3 +40,10 @@ HEADERS += \
+ 
+ DISTFILES += \
+     QDeToTxtlog.pri
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += qDebugToTxtLog.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
+


### PR DESCRIPTION

![QDebugToTxtLog](https://github.com/linuxdeepin/linglong-hub/assets/59505865/04fb818a-baa1-4b7e-aee7-44f4e3617395)

Log: 完成App：QDebugToTxtLog的编译

说明：无可用icon