### PR TITLE
build: add gigole

### DIFF
--- a/org.xfce.gigolo/linglong.yaml
+++ b/org.xfce.gigolo/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: org.xfce.gigolo
+  name: gigolo
+  version: 0.5.3
+  kind: app
+  description: |
+    Gigolo is a frontend to easily manage connections to local and remote.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+   - id: automake/1.16.5
+
+source:
+  kind: git
+  url: https://salsa.debian.org/xfce-team/apps/gigolo.git
+  commit: 7110a3c0b96fb0139a1a84609f81405fb86a66fc
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./configure ${conf_args} ${extra_args}
+ 


### PR DESCRIPTION

![截图_选择区域_20231120194731](https://github.com/linuxdeepin/linglong-hub/assets/84424520/907e6294-f806-4f9f-a9f8-70d88e70fe2e)

Gigolo is a frontend to easily manage connections to local and remote filesystems using GIO/GVfs.

log: add sofware--gigole