### PR TITLE
build: add USBCAN-GUI

### DIFF
--- a/io.github.USBCAN-GUI/linglong.yaml
+++ b/io.github.USBCAN-GUI/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.USBCAN-GUI
+  name: USBCAN-GUI
+  version: 1.0.0
+  kind: app
+  description: |
+    This is a Linux-based GUI (shown below) to interact with the USB-CAN analyzer in order to send and receive packets over a CAN bus.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport
+    type: runtime
+    version: 5.15.7
+
+source:
+  kind: git
+  url: https://github.com/langroodi/USBCAN-GUI.git
+  commit: 54eb2c46f395cbaa5c10fd9282e1185dfee19124
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.USBCAN-GUI/patches/0001-install.patch
+++ b/io.github.USBCAN-GUI/patches/0001-install.patch
@@ -1,0 +1,43 @@
+From f0b2cc0ff29d34f682465941696e2065d09710e3 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 21 Nov 2023 10:39:37 +0800
+Subject: [PATCH] install
+
+---
+ UsbCan.desktop | 8 ++++++++
+ UsbCan.pro     | 6 ++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 UsbCan.desktop
+
+diff --git a/UsbCan.desktop b/UsbCan.desktop
+new file mode 100644
+index 0000000..cec5c5c
+--- /dev/null
++++ b/UsbCan.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=UsbCan
++Name=UsbCan
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/UsbCan.pro b/UsbCan.pro
+index 56b053a..b0cf9a4 100644
+--- a/UsbCan.pro
++++ b/UsbCan.pro
+@@ -39,3 +39,9 @@ HEADERS += \
+ 
+ FORMS += \
+         mainwindow.ui
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =UsbCan.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
This is a Linux-based GUI (shown below) to interact with the USB-CAN analyzer in order to send and receive packets over a CAN bus.

Log: add software name--USBCAN-GUI
![USBCAN-GUI](https://github.com/linuxdeepin/linglong-hub/assets/147463620/232f2f6e-20ba-4777-90e8-2246ece6d98a)
