### PR TITLE
build: add To-do-list-GUI

### DIFF
--- a/io.github.To-do-list-GUI/linglong.yaml
+++ b/io.github.To-do-list-GUI/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.To-do-list-GUI
+  name: To-do-list-GUI
+  version: 0.0.1
+  kind: app
+  description: |
+    A GUI application for Linux and windows that saves a list that you can check off
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/BOB450/To-do-list-GUI.git
+  commit: 082db3895c8e486fd982e018cd5b212da21fe91d
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd ToDoList
+      qmake -makefile  ${conf_args} ${extra_args}

--- a/io.github.To-do-list-GUI/patches/0001-install.patch
+++ b/io.github.To-do-list-GUI/patches/0001-install.patch
@@ -1,0 +1,50 @@
+From 255bfc803554e15616ede498310610890c72ce85 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 21 Nov 2023 10:58:47 +0800
+Subject: [PATCH] install
+
+---
+ ToDoList/ToDoList.desktop | 8 ++++++++
+ ToDoList/ToDoList.pro     | 8 +++++++-
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+ create mode 100644 ToDoList/ToDoList.desktop
+
+diff --git a/ToDoList/ToDoList.desktop b/ToDoList/ToDoList.desktop
+new file mode 100644
+index 0000000..378abfc
+--- /dev/null
++++ b/ToDoList/ToDoList.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=ToDoList
++Name=ToDoList
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/ToDoList/ToDoList.pro b/ToDoList/ToDoList.pro
+index 6613465..4cc0f0d 100644
+--- a/ToDoList/ToDoList.pro
++++ b/ToDoList/ToDoList.pro
+@@ -21,8 +21,14 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
+ RESOURCES += \
+     resource.qrc
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =ToDoList.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A GUI application for Linux and windows that saves a list that you can check off

Log: add software name--To-do-list-GUI
![To-do-list-GUI](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b2a5fd3f-dbad-4e55-b1a8-0f6362b56b34)
