### PR TITLE
build: add app giduba

### DIFF
--- a/io.github.giduba/linglong.yaml
+++ b/io.github.giduba/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.giduba
+  name: giduba
+  version: 1.0.0
+  kind: app
+  description: |
+    A lean, small, and simple Text Editor / Notepad Alternative for Linux.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ncravino/giduba.git
+  commit: 2d7962b6720fa4fd03ad05295ccaefb522400543
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake

--- a/io.github.giduba/patches/fix_install.patch
+++ b/io.github.giduba/patches/fix_install.patch
@@ -1,0 +1,13 @@
+diff --git a/Giduba.pro b/Giduba.pro
+index d7dfbc9..4997dd2 100644
+--- a/Giduba.pro
++++ b/Giduba.pro
+@@ -20,3 +20,8 @@ QMAKE_CXXFLAGS_RELEASE -= -O3
+ QMAKE_CXXFLAGS_RELEASE *= -s -Os -flto
+ QMAKE_LFLAGS += -s -flto
+
++target.path = $$PREFIX/bin
++desktop.path = $$PREFIX/share/applications
++desktop.files += scripts/packaging/com.ncravino.giduba.desktop
++
++INSTALLS += target desktop


### PR DESCRIPTION
A lean, small, and simple Text Editor / Notepad Alternative for Linux.

Logs: add app name--giduba

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/a56ee2eb-4b8e-4601-bc8f-26d048613f3a)
