### PR TITLE
build: add app QClipboard

### DIFF
--- a/io.github.QClipboard/linglong.yaml
+++ b/io.github.QClipboard/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.QClipboard
+  name: QClipboard
+  version: 1.0.4
+  kind: app
+  description: |
+    A cross-platform clipboard tool.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: cmake/3.28.0
+
+source:
+  kind: git
+  url: https://github.com/L-Super/QClipboard.git
+  commit: 106482f1132421a504f95e7c503751b59289e86a
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: cmake

--- a/io.github.QClipboard/patches/fix_install.patch
+++ b/io.github.QClipboard/patches/fix_install.patch
@@ -1,0 +1,28 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 979b326..3955c62 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -76,4 +76,8 @@ if (WIN32)
+             #        --no-translations --no-compiler-runtime
+             $<TARGET_FILE:${PROJECT_NAME}>
+     )
+-endif ()
+\ No newline at end of file
++endif ()
++
++install(TARGETS QClipboard DESTINATION bin/)
++install(FILES QClipboard.desktop DESTINATION share/applications/)
++install(FILES resources/images/clipboard2.svg DESTINATION share/icons/ RENAME QClipboard.svg)
+diff --git a/src/QClipboard.desktop b/src/QClipboard.desktop
+new file mode 100644
+index 0000000..6ce0ecd
+--- /dev/null
++++ b/src/QClipboard.desktop
+@@ -0,0 +1,7 @@
++[Desktop Entry]
++Name=QClipboard
++Comment=A cross-platform clipboard tool.
++Exec=QClipboard %F
++Icon=QClipboard
++Type=Application
++


### PR DESCRIPTION
A cross-platform clipboard tool.

Logs: add app name--QClipboard

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/bf8905b2-b781-48b1-9cd9-5e4aa2b4438e)