### PR TITLE
build: add app Simple-Text-Editor

### DIFF
--- a/io.github.Simple-Text-Editor/linglong.yaml
+++ b/io.github.Simple-Text-Editor/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.Simple-Text-Editor
+  name: Simple-Text-Editor
+  version: 0.1.0
+  kind: app
+  description: |
+    Simple-Text-Editor, as the name suggests, is a simple text editor made with the Qt framework.  
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/tim-gromeyer/Simple-Text-Editor.git
+  commit: 404663fe1961306c4c88d460c95cd3b2c71e611f
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+
+      

--- a/io.github.Simple-Text-Editor/patches/0001-install.patch
+++ b/io.github.Simple-Text-Editor/patches/0001-install.patch
@@ -1,0 +1,55 @@
+From bfebd2b0f1d8e97d798ae21a7bce3ee6902f98eb Mon Sep 17 00:00:00 2001
+From: aizhuzhudegua <1648476050@qq.com>
+Date: Wed, 22 Nov 2023 16:40:28 +0800
+Subject: [install.patch_] install
+
+---
+ Simple-Text-Editor.pro | 18 ++++++++++++++++++
+ TextEditor.desktop     |  8 ++++++++
+ 2 files changed, 26 insertions(+)
+ create mode 100644 TextEditor.desktop
+
+diff --git a/Simple-Text-Editor.pro b/Simple-Text-Editor.pro
+index d93ac53..bb40eeb 100644
+--- a/Simple-Text-Editor.pro
++++ b/Simple-Text-Editor.pro
+@@ -47,3 +47,21 @@ DISTFILES += \
+ 
+ ANDROID_PACKAGE_SOURCE_DIR = \
+         $$PWD/android
++
++
++unix: {
++
++target.path = $${PREFIX}/bin
++INSTALLS += target
++
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = TextEditor.desktop
++INSTALLS += unix_desktop
++
++unix_icons.path = $${PREFIX}/share/icons/
++unix_icons.files = Icon.png
++INSTALLS += unix_icons
++
++
++}
+diff --git a/TextEditor.desktop b/TextEditor.desktop
+new file mode 100644
+index 0000000..49e2786
+--- /dev/null
++++ b/TextEditor.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Exec=Simple-Text-Editor
++GenericName=Simple-Text-Editor
++Hidden=false
++Name=Simple-Text-Editor
++StartupNotify=false
++Type=Application
++Icon=Icon
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Simple-Text-Editor, as the name suggests, is a simple text editor made with the Qt framework.

Logs: add app name--Simple-Text-Editor
![dcd2350bf6b9fdf6fc16af732266626](https://github.com/linuxdeepin/linglong-hub/assets/147809353/60d5380e-c141-4bb2-abc1-bec4bebfb5f4)
