### PR TITLE
build: add autoconf

### DIFF
--- a/autoconf/linglong.yaml
+++ b/autoconf/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: autoconf
+  name: autoconf
+  version: 2.4.7
+  kind: lib
+  description: |
+    Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages.
+
+depends:
+  - id: automake/1.16.5
+  - id: texinfo/6.8.1
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/deepin-community/autoconf.git"
+  commit: 5742e95e78704694a8b3645ca795969f4e60cabc
+
+build:
+  kind: autotools

--- a/extra-cmake-modules/linglong.yaml
+++ b/extra-cmake-modules/linglong.yaml
@@ -1,7 +1,7 @@
 package:
   id: extra-cmake-modules  
   name: extra-cmake-modules  
-  version: 5.111.0
+  version: 5.245.0
   kind: lib
   description: |
     Extra CMake Modules , or ECM.
@@ -12,8 +12,8 @@ base:
 
 source:
   kind: git
-  url: "https://invent.kde.org/frameworks/extra-cmake-modules.git"
-  commit: e9f771e006f26ad79efa2eee18c99bfd8b1b2aaf
-
+  url: "https://github.com/KDE/extra-cmake-modules.git
+  commit: 0ea9fc494b749a39d0110a9de8227d7723596ce6
+    
 build:
   kind: cmake


### PR DESCRIPTION
Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages.

log: 添加lib autoconf