### PR TITLE
build: add lib poppler-data

### DIFF
--- a/poppler-data/linglong.yaml
+++ b/poppler-data/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: poppler-data
+  name: poppler-data
+  version: 0.4.12
+  kind: lib
+  description: |
+    Data files for poppler to support uncommon encodings without xpdfrc.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://gitlab.freedesktop.org/poppler/poppler-data.git
+  commit: af9f452b427d5ce8abe81ff98cc40c5f39fad90b
+
+build:
+  kind: manual
+  manual:
+    install: |
+      make install prefix=${PREFIX} DESTDIR=${dest_dir}


### PR DESCRIPTION
Data files for poppler to support uncommon encodings without xpdfrc.

Logs: add lib poppler-data

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/e8a11fe4-ac00-480c-acfa-a43af0270d7f)
