### PR TITLE
build: add QDocErrorTracker

### DIFF
--- a/io.github.QDocErrorTracker/linglong.yaml
+++ b/io.github.QDocErrorTracker/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.QDocErrorTracker
+  name: QDocErrorTracker
+  version: 0.0.1
+  kind: app
+  description: |
+    A tool to help Qt developers keep track of issues in the Qt documentation.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/JKSH/QDocErrorTracker.git"
+  commit: 4f7d6e0dc40c3d8155280c8917aaa9c1b938679d
+  patch:
+    - patches/add-desktop.patch
+
+build:
+  kind: qmake
+  manual :
+    configure: |
+      cd src
+      qmake -makefile ${conf_args} ${extra_args}

--- a/io.github.QDocErrorTracker/patches/add-desktop.patch
+++ b/io.github.QDocErrorTracker/patches/add-desktop.patch
@@ -1,0 +1,25 @@
+diff --git a/src/QDocErrorTracker.desktop b/src/QDocErrorTracker.desktop
+new file mode 100644
+index 0000000..f454066
+--- /dev/null
++++ b/src/QDocErrorTracker.desktop
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Type=Application
++Name=QDocErrorTracker
++Exec=QDocErrorTracker %f
+diff --git a/src/QDocErrorTracker.pro b/src/QDocErrorTracker.pro
+index 9597930..15b9199 100644
+--- a/src/QDocErrorTracker.pro
++++ b/src/QDocErrorTracker.pro
+@@ -27,3 +27,10 @@ HEADERS  += \
+ FORMS    += \
+     gui.ui \
+     fileselectiondialog.ui
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += QDocErrorTracker.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION

![QDocErrorTracker](https://github.com/linuxdeepin/linglong-hub/assets/59505865/9c9477a6-50e7-4bb5-b113-f21846d1f20f)

Log: 完成app：QDocErrorTracker的编译

说明：无可用icon