### PR TITLE
build: add ExeQt

### DIFF
--- a/io.github.ExeQt/linglong.yaml
+++ b/io.github.ExeQt/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.ExeQt
+  name: ExeQt
+  version: 1.2..2
+  kind: app
+  description: |
+    A nifty little utility for pinning commands, applications or links to the system tray
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/AlexandruIstrate/ExeQt.git
+  commit: c10a36df418c7fbc39000c15f9840e36077719db
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd ExeQt
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.ExeQt/patches/0001-install.patch
+++ b/io.github.ExeQt/patches/0001-install.patch
@@ -1,0 +1,43 @@
+From f1b5fc2f5b7f8a0eb20773d078d37cd9949ea229 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 23 Nov 2023 11:49:28 +0800
+Subject: [PATCH] install
+
+---
+ ExeQt/TrayIcon.desktop | 8 ++++++++
+ ExeQt/TrayIcon.pro     | 6 ++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 ExeQt/TrayIcon.desktop
+
+diff --git a/ExeQt/TrayIcon.desktop b/ExeQt/TrayIcon.desktop
+new file mode 100644
+index 0000000..429a0bc
+--- /dev/null
++++ b/ExeQt/TrayIcon.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=TrayIcon
++Name=TrayIcon
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/ExeQt/TrayIcon.pro b/ExeQt/TrayIcon.pro
+index aea5be8..e9e75ec 100644
+--- a/ExeQt/TrayIcon.pro
++++ b/ExeQt/TrayIcon.pro
+@@ -144,3 +144,9 @@ DISTFILES += \
+ #ifdef Q_WS_WIN
+ RC_ICONS = $$PWD/assets/images/app-icon.ico
+ #endif
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =TrayIcon.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A nifty little utility for pinning commands, applications or links to the system tray.

Log: add software name--ExeQt
![ExeQt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/eff88ba2-5042-4245-ad10-a59cb0846c6d)
