### PR TITLE
build: add app ghostwriter

### DIFF
--- a/io.github.ghostwriter/linglong.yaml
+++ b/io.github.ghostwriter/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.ghostwriter
+  name: ghostwriter
+  version: 1.8.1
+  kind: app
+  description: |
+    ghostwriter is a Windows and Linux text editor for Markdown, which is a plain text markup format created by John Gruber.  
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine
+    version: 5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/refaqtor/ghostwriter.git
+  commit: d23a71b912429719ebbb873d0d8cd64e11b39fe9
+
+
+build:
+  kind: qmake
+
+      


### PR DESCRIPTION
ghostwriter is a Windows and Linux text editor for Markdown, which is a plain text markup format created by John Gruber.

Logs: QtMusic app name--ghostwriter
![d3fbb5e0e8f778adb0ff5cd4799083b](https://github.com/linuxdeepin/linglong-hub/assets/147809353/30f230a5-b1d0-4bd4-beaa-77547fea7f1b)
