### PR TITLE
build: add usb2sniffer-qt

### DIFF
--- a/io.github.usb2sniffer-qt/linglong.yaml
+++ b/io.github.usb2sniffer-qt/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.usb2sniffer-qt 
+  name: usb2sniffer-qt
+  version: 1.1.0
+  kind: app
+  description: |
+    Qt-based software for USB2Sniffer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/lambdaconcept/usb2sniffer-qt.git"
+  commit: aa2d18b3f6758781c8062280166e9fcfc9bb80e6
+  patch:
+    - patches/install-desktop.patch
+
+build:
+  kind: qmake

--- a/io.github.usb2sniffer-qt/patches/install-desktop.patch
+++ b/io.github.usb2sniffer-qt/patches/install-desktop.patch
@@ -1,0 +1,29 @@
+diff --git a/lcsniff.desktop b/lcsniff.desktop
+new file mode 100644
+index 0000000..ad4b5bb
+--- /dev/null
++++ b/lcsniff.desktop
+@@ -0,0 +1,5 @@
++[Desktop Entry]
++Type=Application
++Name=lcsniff
++Exec=lcsniff %f
++Icon=logo-alpha-small
+diff --git a/lcsniff.pro b/lcsniff.pro
+index f1f212a..ba18cba 100644
+--- a/lcsniff.pro
++++ b/lcsniff.pro
+@@ -106,6 +106,13 @@ isEmpty(PREFIX) {
+        target.path = $$PREFIX/bin
+        INSTALLS += target
+ }
++desktop.path = $$PREFIX/share/applications
++desktop.files += lcsniff.desktop
++INSTALLS += desktop
++
++icons.path = $${PREFIX}/share/icons
++icons.files = icons/logo-alpha-small.png
++INSTALLS += icons
+ 
+ RESOURCES += \
+     resources.qrc


### PR DESCRIPTION
finish build usb2sniffer-qt for ll-build

Log: 完成usb2sniffer-qt的编译

![usb2sniffer-qt](https://github.com/linuxdeepin/linglong-hub/assets/142959458/bc9bb9ba-a6a4-433c-a060-2109134eab29)
