### PR TITLE
build: add Qt_Textpad

### DIFF
--- a/io.github.Qt_Textpad/linglong.yaml
+++ b/io.github.Qt_Textpad/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.Textpad
+  name: Textpad
+  version: 0.0.1
+  kind: app
+  description: |
+    Qt C++ Notepad Application.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/theydvgaurav/Qt_Textpad.git"
+  commit: f9f82ca2e147c776e21294d072693fef4b6f5584
+  patch:
+    - patches/add-desktop-file-patch.patch
+    - patches/install-desktop-file-patch.patch
+
+build:
+  kind: qmake

--- a/io.github.Qt_Textpad/patches/add-desktop-file-patch.patch
+++ b/io.github.Qt_Textpad/patches/add-desktop-file-patch.patch
@@ -1,0 +1,11 @@
+diff --git a/TextPad.desktop b/TextPad.desktop
+new file mode 100644
+index 0000000..6aee768
+--- /dev/null
++++ b/TextPad.desktop
+@@ -0,0 +1,5 @@
++[Desktop Entry]
++Type=Application
++Name=TextPad
++Exec=TextPad %f
++Icon=logo

--- a/io.github.Qt_Textpad/patches/install-desktop-file-patch.patch
+++ b/io.github.Qt_Textpad/patches/install-desktop-file-patch.patch
@@ -1,0 +1,15 @@
+diff --git a/TextPad.pro b/TextPad.pro
+index 9d69d26..037da68 100644
+--- a/TextPad.pro
++++ b/TextPad.pro
+@@ -32,3 +32,10 @@ TRANSLATIONS += \
+ qnx: target.path = /tmp/$${TARGET}/bin
+ else: unix:!android: target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += TextPad.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++ INSTALLS += target


### PR DESCRIPTION
Finish build Qt_Textpad for ll-build

Log: 完成Qt_Textpad的编译，无icon

![io github Qt_Textpad_20231124211650](https://github.com/linuxdeepin/linglong-hub/assets/68770570/12358279-be4d-4406-b892-f1e5252a8c0f)
