### PR TITLE
build: lib Hamlib

### DIFF
--- a/Hamlib/linglong.yaml
+++ b/Hamlib/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: Hamlib
+  name: Hamlib
+  version: 4.5.5
+  kind: lib
+  description: |
+    The purpose of this project is to provide stable, flexible, shared libraries that enable quicker development of Amateur Radio Equipment Control Applications.
+
+
+depends:
+  - id: automake/1.16.5
+  - id: libtool
+    version: 2.4.2
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/Hamlib/Hamlib.git
+  commit: f255f6f8d8412c423a2fffb4864e11200f45491f
+
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./bootstrap
+      ./configure ${conf_args} ${extra_args}


### PR DESCRIPTION
Hamlib,一个依赖库，应用klog依赖其进行打包编译。

Log: finish lib Hamlib.

![0220f63a982ffb5bbdfadba8ee2266ff](https://github.com/linuxdeepin/linglong-hub/assets/115330610/df2a1105-e056-4083-847e-6f444bcd5fa9)
