### PR TITLE
build: add Drawing-Board-Sigma

### DIFF
--- a/io.github.Drawing-Board-Sigma/linglong.yaml
+++ b/io.github.Drawing-Board-Sigma/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.Drawing-Board-Sigma
+  name: Drawing-Board-Sigma
+  version: 0.7.0
+  kind: app
+  description: 
+    Qt GUI application.It supports plugin.It can draw rectangle, circle, ellipse, straight line ,triangle and ... scribble model, and you can move them to suitable position.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/Lw-Cui/Drawing-Board-Sigma.git"
+  commit: ad3c34dc40ef95e18f336aeb2ab86751023c0111
+  patch:
+    - patches/0001-1.patch
+
+build:
+  kind: qmake

--- a/io.github.Drawing-Board-Sigma/patches/0001-1.patch
+++ b/io.github.Drawing-Board-Sigma/patches/0001-1.patch
@@ -1,0 +1,49 @@
+From 7b287bde9bf34b8eaad8caf5b88bb6b40f55940c Mon Sep 17 00:00:00 2001
+From: LLLLSHANG <742851145@qq.com>
+Date: Sun, 3 Dec 2023 12:57:43 +0800
+Subject: [PATCH] 1
+
+---
+ drawingBoard/drawingBoard.desktop |  9 +++++++++
+ drawingBoard/drawingBoard.pro     | 11 +++++++++++
+ 2 files changed, 20 insertions(+)
+ create mode 100644 drawingBoard/drawingBoard.desktop
+
+diff --git a/drawingBoard/drawingBoard.desktop b/drawingBoard/drawingBoard.desktop
+new file mode 100644
+index 0000000..36a15c0
+--- /dev/null
++++ b/drawingBoard/drawingBoard.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=drawingBoard
++Name=drawingBoard
++Icon=scribble
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/drawingBoard/drawingBoard.pro b/drawingBoard/drawingBoard.pro
+index 11ddb99..187ef0a 100644
+--- a/drawingBoard/drawingBoard.pro
++++ b/drawingBoard/drawingBoard.pro
+@@ -24,3 +24,14 @@ HEADERS  += \
+ 
+ RESOURCES += \
+     image.qrc
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =drawingBoard.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
++
++icons.path = $${PREFIX}/share/icons
++icons.files = resources/scribble.png
++INSTALLS += icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Finish build Drawing-Board-Sigma for ll-build

Log: 完成Drawing-Board-Sigma的编译

![1701488011818](https://github.com/linuxdeepin/linglong-hub/assets/150589759/49a06b41-d682-44da-b1ae-c26d98d1edf8)
