### PR TITLE
build: add ragingmidi

### DIFF
--- a/io.github.ragingmidi/linglong.yaml
+++ b/io.github.ragingmidi/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.ragingmidi
+  name: ragingmidi
+  version: 0.0.1
+  kind: app
+  description: |
+    Qt-based cross-platform MIDI editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dualword/ragingmidi.git
+  commit: 7153bf68667fba7540541dddcd3ae5e5a02572f9
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+
+
+

--- a/io.github.ragingmidi/patches/0001-install.patch
+++ b/io.github.ragingmidi/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From b93886028432a52287911501e5758a58637975fb Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 2 Dec 2023 11:45:27 +0800
+Subject: [PATCH] install
+
+---
+ src/RagingMidi.pro     | 9 +++++++++
+ src/ragingmidi.desktop | 9 +++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 src/ragingmidi.desktop
+
+diff --git a/src/RagingMidi.pro b/src/RagingMidi.pro
+index 7d12e30..162a08b 100644
+--- a/src/RagingMidi.pro
++++ b/src/RagingMidi.pro
+@@ -79,3 +79,12 @@ exists(../.git/HEAD) {
+ } !exists(Resources/REVISION.txt) {
+     system(echo ???????????????????????????????????????? >Resources/REVISION.txt)
+ }
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =ragingmidi.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = Resources/Logo.ico
++icons.path = $$PREFIX/share/icons
++INSTALLS += target desktop icons
+\ No newline at end of file
+diff --git a/src/ragingmidi.desktop b/src/ragingmidi.desktop
+new file mode 100644
+index 0000000..1e19305
+--- /dev/null
++++ b/src/ragingmidi.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=ragingmidi
++Name=ragingmidi
++icon=Logo
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Qt-based cross-platform MIDI editor.

Log: add software name--ragingmidi
![ragingmidi](https://github.com/linuxdeepin/linglong-hub/assets/147463620/88ad34b0-4e38-473f-be84-556d9af751e7)
