### PR TITLE
build: add GetLinuxAppsInfo

### DIFF
--- a/io.github.GetLinuxAppsInfo/linglong.yaml
+++ b/io.github.GetLinuxAppsInfo/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.GetLinuxAppsInfo
+  name: GetLinuxAppsInfo
+  version: 1.0.0
+  kind: app
+  description: |
+   扫描Linux上所有已安装软件，基于Qt实现---Scan all installed software on Linux, based on Qt implementation.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/SantaJiang/GetLinuxAppsInfo.git
+  commit: 06695e076fd47bf21a56ac8b227049d8491f7ace
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.GetLinuxAppsInfo/patches/0001-install.patch
+++ b/io.github.GetLinuxAppsInfo/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From 550a6cd749732b7ec54fcd6a4ed6c3c055354a7e Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 30 Nov 2023 16:27:11 +0800
+Subject: [PATCH] install
+
+---
+ GetLinuxAppsInfo.desktop | 8 ++++++++
+ GetLinuxAppsInfo.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 GetLinuxAppsInfo.desktop
+
+diff --git a/GetLinuxAppsInfo.desktop b/GetLinuxAppsInfo.desktop
+new file mode 100644
+index 0000000..1d70cad
+--- /dev/null
++++ b/GetLinuxAppsInfo.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=GetLinuxAppsInfo
++Name=GetLinuxAppsInfo
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/GetLinuxAppsInfo.pro b/GetLinuxAppsInfo.pro
+index 6c08d3b..c0dda09 100644
+--- a/GetLinuxAppsInfo.pro
++++ b/GetLinuxAppsInfo.pro
+@@ -34,3 +34,10 @@ HEADERS += \
+ 
+ FORMS += \
+         mainwindow.ui
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =GetLinuxAppsInfo.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
扫描Linux上所有已安装软件，基于Qt实现---Scan all installed software on Linux, based on Qt implementation.

Log: add software name--GetLinuxAppsInfo
![GetLinuxAppsInfo](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ab573493-e46b-44c0-8c61-2493f112f8c3)
