### PR TITLE
build: add GetScreenGeometry

### DIFF
--- a/io.github.GetScreenGeometry/linglong.yaml
+++ b/io.github.GetScreenGeometry/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.GetScreenGeometry
+  name: GetScreenGeometry
+  version: 1.0.0
+  kind: app
+  description: |
+    Qt实现的获取屏幕分辨率小工具，支持Win/Linux---Get screen resolution widget realized by Qt,Support Win/Linux.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/SantaJiang/GetScreenGeometry.git
+  commit: 8e3134a1e8662a72b97fd65a93bd47212b5ba1bf
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.GetScreenGeometry/patches/0001-install.patch
+++ b/io.github.GetScreenGeometry/patches/0001-install.patch
@@ -1,0 +1,46 @@
+From c113f219ad1e61f3c5270fb3a83f601657c2ee5b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 30 Nov 2023 16:44:35 +0800
+Subject: [PATCH] install
+
+---
+ GetScreenGeometry.desktop | 9 +++++++++
+ GetScreenGeometry.pro     | 9 +++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 GetScreenGeometry.desktop
+
+diff --git a/GetScreenGeometry.desktop b/GetScreenGeometry.desktop
+new file mode 100644
+index 0000000..5449898
+--- /dev/null
++++ b/GetScreenGeometry.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=GetScreenGeometry
++Name=GetScreenGeometry
++icons=logo.ico
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/GetScreenGeometry.pro b/GetScreenGeometry.pro
+index 429ffd4..89a53a7 100644
+--- a/GetScreenGeometry.pro
++++ b/GetScreenGeometry.pro
+@@ -25,3 +25,12 @@ RC_ICONS = logo.ico
+ 
+ RESOURCES += \
+     root.qrc
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =GetScreenGeometry.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = logo.ico
++icons.path = $$PREFIX/share/icons
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
Qt实现的获取屏幕分辨率小工具，支持Win/Linux---Get screen resolution widget realized by Qt,Support Win/Linux.

Log: add software name--GetScreenGeometry
![GetScreenGeometry](https://github.com/linuxdeepin/linglong-hub/assets/147463620/d3664e10-3d44-4e8c-a0e7-a574766ee5c7)
