### PR TITLE
build: add GameMakerLegacyHelper

### DIFF
--- a/io.github.GameMakerLegacyHelper/linglong.yaml
+++ b/io.github.GameMakerLegacyHelper/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.GameMakerLegacyHelper
+  name: GameMakerLegacyHelper
+  version: 0.1.0.1
+  kind: app
+  description: |
+    The program helps to correct inaccuracies in the conversion of projects from Game Maker 7/8 to Game Maker Studio 1 and GameMaker (Studio 2).
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/3dproger/GameMakerLegacyHelper.git
+  commit: 6920e57191573fd87f42037eb60957272546b56b
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile GameMakerLegacyHelper.pro ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.GameMakerLegacyHelper/patches/0001-install.patch
+++ b/io.github.GameMakerLegacyHelper/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 4d2d18ddc52f098b670a536871cffd2eda69134f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 1 Dec 2023 10:39:06 +0800
+Subject: [PATCH] install
+  
+---
+ src/GameMakerLegacyHelper.desktop | 8 ++++++++
+ src/GameMakerLegacyHelper.pro     | 9 ++++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 src/GameMakerLegacyHelper.desktop
+
+diff --git a/src/GameMakerLegacyHelper.desktop b/src/GameMakerLegacyHelper.desktop
+new file mode 100644
+index 0000000..0929fff
+--- /dev/null
++++ b/src/GameMakerLegacyHelper.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=GameMakerLegacyHelper
++Name=GameMakerLegacyHelper
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/src/GameMakerLegacyHelper.pro b/src/GameMakerLegacyHelper.pro
+index 30717ff..d63bd87 100644
+--- a/src/GameMakerLegacyHelper.pro
++++ b/src/GameMakerLegacyHelper.pro
+@@ -45,5 +45,12 @@ win32: {
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =GameMakerLegacyHelper.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
The program helps to correct inaccuracies in the conversion of projects from Game Maker 7/8 to Game Maker Studio 1 and GameMaker (Studio 2)

Log: add software name--GameMakerLegacyHelper
![GameMakerLegacyHelper](https://github.com/linuxdeepin/linglong-hub/assets/147463620/f6de892d-9779-48da-9954-645494816045)
