### PR TITLE
build: add dualword-wiki

### DIFF
--- a/io.github.dualword-wiki/linglong.yaml
+++ b/io.github.dualword-wiki/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.dualword-wiki
+  name: dualword-wiki
+  version: 1.1.0
+  kind: app
+  description: |
+    
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+    type: runtime
+  - id: qtxmlpatterns/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/dualword/dualword-wiki.git
+  commit: 0f80791776d994fca034e42299d1b927f4d3c219
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.dualword-wiki/patches/0001-install.patch
+++ b/io.github.dualword-wiki/patches/0001-install.patch
@@ -1,0 +1,43 @@
+From 7a6156ee9085c3d437ca01109dbdbc70e73c0b99 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 1 Dec 2023 11:20:32 +0800
+Subject: [PATCH] install
+
+---
+ src/dualword-wiki.desktop | 8 ++++++++
+ src/src.pro               | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 src/dualword-wiki.desktop
+
+diff --git a/src/dualword-wiki.desktop b/src/dualword-wiki.desktop
+new file mode 100644
+index 0000000..90c94c5
+--- /dev/null
++++ b/src/dualword-wiki.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=dualword-wiki
++Name=dualword-wiki
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/src/src.pro b/src/src.pro
+index e8bb092..3e86334 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -50,3 +50,10 @@ OBJECTS_DIR = .build/obj
+ MOC_DIR     = .build/moc
+ RCC_DIR     = .build/rcc
+ UI_DIR      = .build/ui
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =dualword-wiki.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
Wikipedia browser.

Log: add software name--dualword-wiki
![dualword-wiki](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b245b316-1b26-40fa-9fbc-3275889542fb)
