### PR TITLE
build: add SerialPortAssistant

### DIFF
--- a/io.github.SerialPortAssistant/linglong.yaml
+++ b/io.github.SerialPortAssistant/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.SerialPortAssistant
+  name: SerialPortAssistant
+  version: 1.0.0
+  kind: app
+  description: |
+    A simple serial port assistant software make by Qt5
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/hubenchang0515/SerialPortAssistant.git
+  commit: 1d56a868a6fae4def4fee008e1030924ebf85faa
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.SerialPortAssistant/patches/0001-install.patch
+++ b/io.github.SerialPortAssistant/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From f06f5eaa575961b833d8205541945f34c6455bfd Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 3 Dec 2023 10:22:09 +0800
+Subject: [PATCH] install
+
+---
+ SerialPortAssistant.desktop | 8 ++++++++
+ SerialPortAssistant.pro     | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 SerialPortAssistant.desktop
+
+diff --git a/SerialPortAssistant.desktop b/SerialPortAssistant.desktop
+new file mode 100644
+index 0000000..298e16b
+--- /dev/null
++++ b/SerialPortAssistant.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=SerialPortAssistant
++Name=SerialPortAssistant
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/SerialPortAssistant.pro b/SerialPortAssistant.pro
+index 86d3dce..46db386 100644
+--- a/SerialPortAssistant.pro
++++ b/SerialPortAssistant.pro
+@@ -25,3 +25,11 @@ CONFIG += c++11
+ 
+ RESOURCES += \
+     resource/resource.qrc
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =SerialPortAssistant.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
++
+-- 
+2.33.1
+


### PR DESCRIPTION
A simple serial port assistant software make by Qt5

Log: add software name--SerialPortAssistant
![SerialPortAssistant](https://github.com/linuxdeepin/linglong-hub/assets/147463620/44119d4b-9494-4011-8ecc-d6382275bea2)
