### PR TITLE
build: add app olive

### DIFF
--- a/io.github.olive/linglong.yaml
+++ b/io.github.olive/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.olive
+  name: olive
+  version: 0.1.2
+  kind: app
+  description: |
+    Free open-source non-linear video editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: lapack/3.8.0.1
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/olive-editor/olive.git
+  commit: 67bfa9d46503c464167c26e6a5a0a7ae7096e757
+  version: 0.1.x
+
+build:
+  kind: cmake


### PR DESCRIPTION
Free open-source non-linear video editor.

Logs: add app name--olive

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/9433542a-708b-40ef-8ccb-9ab2c3abed52)
