### PR TITLE
build: add opus

### DIFF
--- a/opus/linglong.yaml
+++ b/opus/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: opus
+  name: opus 
+  version: 1.4.0
+  kind: lib
+  description: |
+     Opus is a codec for interactive speech and audio transmission over the Internet.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/xiph/opus.git
+  commit: c85499757c148fede8604cffa12454206b6138ba
+
+build:
+  kind: cmake


### PR DESCRIPTION
Opus is a codec for interactive speech and audio transmission over the Internet.

log: add lib