### PR TITLE
build: add OpenRGB

### DIFF
--- a/io.github.OpenRGB/linglong.yaml
+++ b/io.github.OpenRGB/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.OpenRGB
+  name: OpenRGB
+  version: 0.9.0
+  kind: app
+  description: |
+    Open source RGB lighting control that doesn't depend on manufacturer software. Supports Windows, Linux, MacOS. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: hidapi
+    type: runtime
+    version: 0.14.0
+    source:
+      kind: git
+      url: https://github.com/libusb/hidapi.git
+      version: master
+      commit: 7011fa98af2dde00c298105735e470de800288c7
+    build:
+      kind: cmake
+
+source:
+  kind: git
+  url: https://github.com/CalcProgrammer1/OpenRGB.git
+  commit: 308bb6f9b8169c8e1c5123f9499373509f140268
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.OpenRGB/patches/0001-install.patch
+++ b/io.github.OpenRGB/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From ec60bd62757cb33b1674fba959ce2906c476c3a4 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 5 Dec 2023 16:50:16 +0800
+Subject: [PATCH] install
+
+---
+ OpenRGB.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/OpenRGB.pro b/OpenRGB.pro
+index 941be5ce..c8491ae9 100644
+--- a/OpenRGB.pro
++++ b/OpenRGB.pro
+@@ -489,7 +489,7 @@ win32:contains(QMAKE_TARGET.arch, x86) {
+ # Linux-specific Configuration                                          #
+ #-----------------------------------------------------------------------#
+ unix:!macx {
+-    INCLUDEPATH +=                                                      \
++    INCLUDEPATH += ${PREFIX}/include                                                     \
+ 
+     HEADERS +=                                                          \
+     i2c_smbus/i2c_smbus_linux.h                                         \
+-- 
+2.33.1
+


### PR DESCRIPTION
Open source RGB lighting control that doesn't depend on manufacturer software. Supports Windows, Linux, MacOS.

Log: add software name--OpenRGB
![image](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9d04a491-7320-469c-9192-23b076f4ddc0)
