### PR TITLE
build: add phantomstyle

### DIFF
--- a/io.github.phantomstyle/linglong.yaml
+++ b/io.github.phantomstyle/linglong.yaml
@@ -1,0 +1,29 @@
+package:
+  id: io.github.phantomstyle
+  name: phantomstyle
+  version: 0.0.1
+  kind: app
+  description: |
+    Cross-platform QStyle for traditionalists
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/randrew/phantomstyle.git
+  commit: 309c97a955f6cdfb1987d1dd04c34d667e4bfce1
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd funhouse
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install
+

--- a/io.github.phantomstyle/patches/0001-install.patch
+++ b/io.github.phantomstyle/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From 48ac84c65df146016fbe347e319cef96849ba44e Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 4 Dec 2023 19:30:59 +0800
+Subject: [PATCH] install
+
+---
+ funhouse/funhouse.desktop | 8 ++++++++
+ funhouse/funhouse.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 funhouse/funhouse.desktop
+
+diff --git a/funhouse/funhouse.desktop b/funhouse/funhouse.desktop
+new file mode 100644
+index 0000000..e9a07c7
+--- /dev/null
++++ b/funhouse/funhouse.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=funhouse
++Name=funhouse
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/funhouse/funhouse.pro b/funhouse/funhouse.pro
+index 557e245..13b17cc 100644
+--- a/funhouse/funhouse.pro
++++ b/funhouse/funhouse.pro
+@@ -82,3 +82,10 @@ msvc {
+         }
+     }
+ }
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =funhouse.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
++
+-- 
+2.33.1
+


### PR DESCRIPTION
Cross-platform QStyle for traditionalists

Log: add software name--phantomstyle
![phantomstyle](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a8fae97b-8bfa-42fa-9f7b-2041e29ce65b)
