### PR TITLE
build: add QSubber

### DIFF
--- a/io.github.QSubber/linglong.yaml
+++ b/io.github.QSubber/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.QSubber
+  name: QSubber
+  version: 1.0.0
+  kind: app
+  description: |
+    About OpenSubtitles.org Qt5 download client,supporting search by hash, detailed search, download, and other features.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/vaurelios/QSubber.git
+  commit: 1fa5a5429b176229090f1a515ec73749ba38d969
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.QSubber/patches/0001-install.patch
+++ b/io.github.QSubber/patches/0001-install.patch
@@ -1,0 +1,27 @@
+From 240771a7b629219a308ab56c57abf9014b707f87 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 5 Dec 2023 12:13:23 +0800
+Subject: [PATCH] install
+
+---
+ qsubber.pro | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/qsubber.pro b/qsubber.pro
+index 2544e79..0708682 100644
+--- a/qsubber.pro
++++ b/qsubber.pro
+@@ -34,3 +34,10 @@ RCC_DIR = build/.rcc
+ UI_DIR = build/.ui
+ 
+ TARGET = qsubber
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =data/qsubber.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
    About OpenSubtitles.org Qt5 download client,supporting search by hash, detailed search, download, and other features.

Log: add software name--QSubber
![QSubber](https://github.com/linuxdeepin/linglong-hub/assets/147463620/5846792d-86a6-46f9-8fc8-8f10b1926145)
