### PR TITLE
build: add app jmbde-QT

### DIFF
--- a/io.github.jmbde-QT/linglong.yaml
+++ b/io.github.jmbde-QT/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.jmbde-QT
+  name: jmbde-QT
+  version: 0.5.4
+  kind: app
+  description: |
+    A program to collect the resources of a company in a database. These are computers, printers, phones and more.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/jmuelbert/jmbde-QT.git
+  commit: 74a95660fcf2d5dd402e8a15f268c02a69bebafc
+
+build:
+  kind: cmake


### PR DESCRIPTION
A program to collect the resources of a company in a database. These are computers, printers, phones and more.

Logs: add app name--jmbde-QT

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/4e8042af-949d-405c-aa38-c82fb0816264)