### PR TITLE
build: add app scrite

### DIFF
--- a/io.github.scrite/linglong.yaml
+++ b/io.github.scrite/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.scrite
+  name: scrite
+  version: 0.9.4
+  kind: app
+  description: |
+    Crossplatform Screenwriting Software.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+
+source:
+  kind: git
+  url: https://github.com/teriflix/scrite.git
+  commit: 51bb3a1c668b52037f3521f357bb375cb3ea3bb9
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake

--- a/io.github.scrite/patches/fix_install.patch
+++ b/io.github.scrite/patches/fix_install.patch
@@ -1,0 +1,12 @@
+diff --git a/scrite.pro b/scrite.pro
+index c89eeda2..ce441a86 100644
+--- a/scrite.pro
++++ b/scrite.pro
+@@ -362,3 +362,7 @@ win32 {
+     QMAKE_POST_LINK = '/bin/bash -c "touch $$PWD/src/core/application_build_timestamp.cpp"'
+ }
+ 
++target.path = $$PREFIX/bin
++desktop.path = $$PREFIX/share/applications
++desktop.files += packaging/linux/Scrite.desktop
++INSTALLS += desktop target


### PR DESCRIPTION
Crossplatform Screenwriting Software.

Logs: add app name--scrite

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/9d30cc67-bef8-4ff8-a3c0-b169cce4b67d)
