### PR TITLE
build: add app edb-debugger

### DIFF
--- a/io.github.edb-debugger/linglong.yaml
+++ b/io.github.edb-debugger/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.edb-debugger
+  name: edb-debugger
+  version: 1.4.0
+  kind: app
+  description: |
+    edb is a cross-platform AArch32/x86/x86-64 debugger.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: capstone/5.0.1.1
+    type: runtime
+  - id: double-conversion/3.1.0.3
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/eteran/edb-debugger.git
+  commit: 887b217aa575a4bb7f3cda61c5310d2945e32baa
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: cmake

--- a/io.github.edb-debugger/patches/fix_install.patch
+++ b/io.github.edb-debugger/patches/fix_install.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 90fd7f82..03130418 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,7 @@ include_directories("${PROJECT_BINARY_DIR}/include")
+ 
+ find_package(Capstone REQUIRED)
+ include_directories(${CAPSTONE_INCLUDE_DIRS})
++include_directories("/runtime/include")
+ link_directories(${CAPSTONE_LIBRARY_DIRS})
+ 
+ if (UNIX)


### PR DESCRIPTION
edb is a cross-platform AArch32/x86/x86-64 debugger.

Logs: add app name--edb-debugger

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/e6e8d010-eb7c-405f-b4a4-4d50f0ad71db)

需要设置 `plugin directory` 为 `/opt/apps/io.github.edb-debugger/files/lib/x86_64-linux-gnu/edb/`

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/3f2301dc-2ffa-4acb-bf89-3a0a83cdc719)