### PR TITLE
build: add app qlcplus

### DIFF
--- a/io.github.qlcplus/linglong.yaml
+++ b/io.github.qlcplus/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.qlcplus
+  name: qlcplus
+  version: 4.12.7.1
+  kind: app
+  description: |
+    Q Light Controller Plus (QLC+) is a free and cross-platform software to control DMX or analog lighting systems like moving heads, dimmers, scanners etc. This project is a fork of the great QLC project written by Heikki Junnila that aims to continue the QLC development and to introduce new features.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libftdi/1.5.0.1
+
+source:
+  kind: git
+  url: https://github.com/mcallegari/qlcplus.git
+  commit: dcdd102f61cbf62b30495315852ca1acea4c1b57
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake

--- a/io.github.qlcplus/patches/fix_install.patch
+++ b/io.github.qlcplus/patches/fix_install.patch
@@ -1,0 +1,12 @@
+diff --git a/variables.pri b/variables.pri
+index 0fc725800..440c6e5fc 100644
+--- a/variables.pri
++++ b/variables.pri
+@@ -76,7 +76,7 @@ win32:QMAKE_LFLAGS += -Wl,--enable-auto-import
+ # Install root
+ win32:INSTALLROOT       = $$(SystemDrive)/qlcplus
+ macx:INSTALLROOT        = ~/QLC+.app/Contents
+-unix:!macx:INSTALLROOT += /usr
++unix:!macx:INSTALLROOT += $$PREFIX
+ android:INSTALLROOT     = /
+ ios:INSTALLROOT         = /


### PR DESCRIPTION
Q Light Controller Plus (QLC+) is a free and cross-platform software to control DMX or analog lighting systems like moving heads, dimmers, scanners etc. This project is a fork of the great QLC project written by Heikki Junnila that aims to continue the QLC development and to introduce new features.

Logs: add app name--qlcplus

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/9bbd4f1a-eee1-4f0d-a321-ccf60fa6cae6)
