### PR TITLE
build: add colorgrab

### DIFF
--- a/io.github.colorgrab/linglong.yaml
+++ b/io.github.colorgrab/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.colorgrab
+  name: colorgrab
+  version: 0.3.0
+  kind: app
+  description: |
+   A cross-platform color picker.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: wxWidgets/3.2.3
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/nielssp/colorgrab.git
+  commit: e194ca688619d9561c65e1f3ecf18c9dab2cf0f2
+
+build:
+  kind: cmake
+


### PR DESCRIPTION
   A cross-platform color picker.

Log: add software name--colorgrab
![colorgrab](https://github.com/linuxdeepin/linglong-hub/assets/147463620/dfaa313b-b68b-48c4-8761-f8d84637ed52)
