### PR TITLE
build: add maProc

### DIFF
--- a/io.github.maProc/linglong.yaml
+++ b/io.github.maProc/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.maProc
+  name: maProc
+  version: 0.2.5
+  kind: app
+  description: |
+   being able to change the memory with write permission, you can manipulate the process by sending a SIGNAL and can stop or pause it process.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/mentebinaria/maProc.git
+  commit: dee8d4c17bc7f236d98e3f734fd61c35502b7137
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.maProc/patches/0001-install.patch
+++ b/io.github.maProc/patches/0001-install.patch
@@ -1,0 +1,43 @@
+From cc043fb0b0251fecb80aa8975a2678299f19b6e1 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 6 Dec 2023 14:00:06 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt           | 5 ++++-
+ build_dir/maProc.desktop | 8 ++++++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+ create mode 100644 build_dir/maProc.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abe1a3a..2c35cbc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,4 +81,7 @@ set_target_properties(maProc PROPERTIES
+ 
+ if(QT_VERSION_MAJOR EQUAL 6)
+     qt_finalize_executable(maProc)
+-endif()
+\ No newline at end of file
++endif()
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/maProc.desktop DESTINATION share/applications)
++install(TARGETS maProc DESTINATION bin)
+\ No newline at end of file
+diff --git a/build_dir/maProc.desktop b/build_dir/maProc.desktop
+new file mode 100644
+index 0000000..e7542ab
+--- /dev/null
++++ b/build_dir/maProc.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=maProc
++Name=maProc
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+-- 
+2.33.1
+


### PR DESCRIPTION
   being able to change the memory with write permission, you can manipulate the process by sending a SIGNAL and can stop or pause it process.

Log: add software name--maProc
![maProc](https://github.com/linuxdeepin/linglong-hub/assets/147463620/4076b2f8-343e-45ed-9954-c4ac47c94c19)
