### PR TITLE
build: add munt

### DIFF
--- a/io.github.munt/linglong.yaml
+++ b/io.github.munt/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.munt
+  name: munt
+  version: 2.7.1.1
+  kind: app
+  description: |
+    A multi-platform software synthesiser emulating pre-GM MIDI devices such as the Roland MT-32, CM-32L, CM-64 and LAPC-I. In no way endorsed by or affiliated with Roland Corp.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/munt/munt.git
+  commit: 356f3088deff299f9b973484ea9ec89234ce31a0
+
+build:
+  kind: cmake
+  
+

--- a/io.github.munt/patches/0001-install.patch
+++ b/io.github.munt/patches/0001-install.patch
@@ -1,0 +1,34 @@
+From dc261efb3cd0696e611e9a710c7ed68dabc6d7f7 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 7 Dec 2023 09:33:52 +0800
+Subject: [PATCH] install
+ 
+---
+ CMakeLists.txt | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb05792..44e96fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -147,15 +147,12 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall")
+ #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -std=c++11 -Wall")
+ 
+-if(ENABLE_QT5)
++
+ #find_package(Qt5Core REQUIRED)
+ 	find_package(Qt5 COMPONENTS Core Gui Widgets Network REQUIRED)
+ 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}    ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
+ #	set(CMAKE_CXX_FLAGS "-fPIC")
+-else()
+-	# Configure the use of QT4
+-	find_package(Qt4 COMPONENTS QtCore QtNetwork QtGui REQUIRED QUIET)
+-endif()
++
+ 
+ #add libusb and pthreads
+ find_package(libusb-1.0 REQUIRED)
+-- 
+2.33.1
+


### PR DESCRIPTION
    A multi-platform software synthesiser emulating pre-GM MIDI devices such as the Roland MT-32, CM-32L, CM-64 and LAPC-I. In no way endorsed by or affiliated with Roland Corp.

Log: add software name--munt
![munt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/bceca982-a459-4e97-ae94-3d15b4a54a5c)
