### PR TITLE
build: add Intan-RHX

### DIFF
--- a/io.github.Intan-RHX/linglong.yaml
+++ b/io.github.Intan-RHX/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.Intan-RHX
+  name: Intan-RHX
+  version: 3.3.0.1
+  kind: app
+  description: |
+    Intan RHX is free, powerful data acquisition software that displays and records electrophysiological signals from any Intan RHD or RHS system using an RHD USB interface board
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Intan-Technologies/Intan-RHX.git
+  commit: 0829e0b47cf4a9a2a961e5e597a678c7d4d1b096
+  patch: 
+    - patches/0001-install.patch
+    - patches/0002-install.patch
+
+build:
+  kind: qmake

--- a/io.github.Intan-RHX/patches/0001-install.patch
+++ b/io.github.Intan-RHX/patches/0001-install.patch
@@ -1,0 +1,26 @@
+From 9472094e0cac0ba1b5493e6f2c5136e7f3a28dda Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 7 Dec 2023 10:03:21 +0800
+Subject: [PATCH] install
+ 
+---
+ Engine/Processing/DataFileReaders/fileperchannelmanager.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp b/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
+index e3e25b7..224a627 100644
+--- a/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
++++ b/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
+@@ -27,7 +27,8 @@
+ //  See <http://www.intantech.com> for documentation and product information.
+ //
+ //------------------------------------------------------------------------------
+-
++#include <thread>
++#include <chrono>
+ #include <QFileInfo>
+ #include <iostream>
+ #include "rhxglobals.h"
+-- 
+2.33.1
+

--- a/io.github.Intan-RHX/patches/0002-install.patch
+++ b/io.github.Intan-RHX/patches/0002-install.patch
@@ -1,0 +1,51 @@
+From 99b35128681ba23e5d0f3f81560d4829592b633a Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 7 Dec 2023 10:22:32 +0800
+Subject: [PATCH] install
+ 
+---
+ IntanRHX.desktop |  9 +++++++++
+ IntanRHX.pro     | 13 +++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 IntanRHX.desktop
+
+diff --git a/IntanRHX.desktop b/IntanRHX.desktop
+new file mode 100644
+index 0000000..4ba47e5
+--- /dev/null
++++ b/IntanRHX.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=IntanRHX
++Name=IntanRHX
++icon=intan-rhx
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/IntanRHX.pro b/IntanRHX.pro
+index 458ae34..09f73c4 100644
+--- a/IntanRHX.pro
++++ b/IntanRHX.pro
+@@ -289,3 +289,16 @@ LIBS += -L$$PWD/libraries/Linux/ -lokFrontPanel # Opal Kelly Front Panel library
+ QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN\'' # Flag that at runtime, look for shared libraries (like
+                                            # libokFrontPanel.so) at the same directory as the binary
+ }
++
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =IntanRHX.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = images/intan-rhx.svg
++icons.path = $$PREFIX/share/icons
++lib.files = libraries/Linux/libokFrontPanel.so
++lib.path = $$BINDIR
++INSTALLS += target desktop icons lib
+-- 
+2.33.1
+


### PR DESCRIPTION
    Intan RHX is free, powerful data acquisition software that displays and records electrophysiological signals from any Intan RHD or RHS system using an RHD USB interface board

Log: add software name--Intan-RHX
![Intan-RHX](https://github.com/linuxdeepin/linglong-hub/assets/147463620/44d80c7f-053f-4c6d-a0f3-cd06fa3c43cb)
