### PR TITLE
build: add serial_recv_send_qt

### DIFF
--- a/com.gitee.serial_recv_send_qt/linglong.yaml
+++ b/com.gitee.serial_recv_send_qt/linglong.yaml
@@ -1,0 +1,18 @@
+package:
+  id: com.gitee.serial_recv_send_qt
+  name: serial_recv_send_qt
+  version: 1.0.0
+  kind: app
+  description: |
+    windows端串口助手，可在接收到指定数据时进行回复。 一般用于串口配置软件自测试
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://gitee.com/fengyuwuzu0519/serial_recv_send_qt.git"
+  commit: f41e4f7
+  patch: patches/ab.patch
+build:
+  kind: qmake

--- a/com.gitee.serial_recv_send_qt/patches/ab.patch
+++ b/com.gitee.serial_recv_send_qt/patches/ab.patch
@@ -1,0 +1,25 @@
+diff -Naur b/complex.pro a/complex.pro
+--- b/complex.pro	2023-12-07 23:23:10.031860622 +0800
++++ a/complex.pro	2023-12-07 23:38:22.643361663 +0800
+@@ -40,6 +40,11 @@
+         mainwindow.ui
+ 
+ # Default rules for deployment.
+-qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++#qnx: target.path = /tmp/$${TARGET}/bin
++#else: unix:!android: target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++desktop.files += serial_recv_send_qt.desktop
++desktop.path = $${PREFIX}/share/applications
++target.path = $$(PREFIX)/bin
++
++INSTALLS += target desktop
+diff -Naur b/serial_recv_send_qt.desktop a/serial_recv_send_qt.desktop
+--- b/serial_recv_send_qt.desktop	1970-01-01 08:00:00.000000000 +0800
++++ a/serial_recv_send_qt.desktop	2023-12-07 23:38:03.059240815 +0800
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Name=serial_recv_send_qt
++Exec=complex
++Type=Application


### PR DESCRIPTION
Log: add app name--serial_recv_send_qt
build可成功，run缺少库libQt5SerialPort.so.5，本机run不出来
![图片](https://github.com/linuxdeepin/linglong-hub/assets/149229882/409070e7-c2ad-48b2-8dd2-83836c904b3a)
