### PR TITLE
build: add app kapow

### DIFF
--- a/io.github.kapow/linglong.yaml
+++ b/io.github.kapow/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.kapow
+  name: kapow
+  version: 1.5.7
+  kind: app
+  description: |
+    Kapow is a punch clock program designed to easily keep track of your hours, whether you're working on one project or many.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/kapow.git
+  commit: ecf560b191f4bfbc3621552584617af11691be52
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Kapow 是一款打卡钟程序，旨在轻松记录您的时间，无论您正在从事一个项目还是多个项目。只需使用以下命令即可上下班打卡 开始/停止按钮。如果您在工作时间内犯了错误，您可以返回并通过双击相关会话来编辑任何条目。

Log: finish app kapow.

![1dc20f590d960488f066a3ac84d9d105](https://github.com/linuxdeepin/linglong-hub/assets/115330610/69bdc5f5-eabf-44dd-ab34-def38038a5d4)
