### PR TITLE
build: add app novprog

### DIFF
--- a/io.github.novprog/linglong.yaml
+++ b/io.github.novprog/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.novprog
+  name: novprog
+  version: 3.2.0
+  kind: app
+  description: |
+    NovProg is a tool to graph your progress in writing a novel.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/novprog.git
+  commit: e658c78b37298d0a8590653303f4ef9921b0a2bf
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
NovProg 是一个用于绘制小说写作进度的工具。您输入您的wordcount 会更新一个图表，显示您的进度制成。它还会显示您完成每日目标的进度以及您的目标 总目标。将鼠标悬停在图表中的条形上将显示一个工具提示一天的字数。

Log: finish app novprog.

![1d0888cc9c60d06c71bc930b43933faa](https://github.com/linuxdeepin/linglong-hub/assets/115330610/a7f3cd3c-3127-4bab-b343-fddb97e147a2)
