### PR TITLE
build: add app tanglet

### DIFF
--- a/io.github.tanglet/linglong.yaml
+++ b/io.github.tanglet/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.tanglet
+  name: tanglet
+  version: 1.6.0
+  kind: app
+  description: |
+    Tanglet is a single player word finding game based on Boggle. The object of the game is to list as many words as you can before the time runs out.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/tanglet.git
+  commit: 98a5f748a56d22bfb652b2294db7b89dd3abd7ce
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Tanglet 是一款基于 Boggle 的单人找词游戏。物体游戏的重点是在时间用完之前列出尽可能多的单词。 有几种计时器模式可以确定您开始的时间，当你找到一个词时，如果你有额外的时间。

Log: finsih add app tanglet.

![eaa8d5ac9666b942a84823736af8bdb0](https://github.com/linuxdeepin/linglong-hub/assets/115330610/47fd8355-724f-4c3e-b3a6-c7b9d5800607)
