### PR TITLE
build: add app hexalate

### DIFF
--- a/io.github.hexalate/linglong.yaml
+++ b/io.github.hexalate/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.hexalate
+  name: hexalate
+  version: 1.6.0
+  kind: app
+  description: |
+    Hexalate is a color matching game. The goal of the game is to rotate and position the circles so that each touching line matches in color.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/hexalate.git
+  commit: 4d4ac14aa0b3ef4cd2a0d8f41e75c4a34558af5a
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Hexalate 是一款配色游戏。游戏的目标是旋转和定位圆圈，使每条接触线的颜色相匹配。你通过右键单击来旋转圆圈，并通过拖动来移动圆圈。游戏存储各轮运行中圆圈的位置和旋转。

Log: finsih app hexalate.

![1466ac53a522b9f878a414f967cdfe66](https://github.com/linuxdeepin/linglong-hub/assets/115330610/9c214f55-7ad3-41bc-b533-3c012f0519ef)
