### PR TITLE
build: add app gottet

### DIFF
--- a/io.github.gottet/linglong.yaml
+++ b/io.github.gottet/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.gottet
+  name: gottet
+  version: 1.2.0
+  kind: app
+  description: |
+    Gottet is a clone of Tetris I wrote.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/gottet.git
+  commit: 530c4d93839db266678e2d5b630ce2be14e002c7
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Gottet 是俄罗斯方块的克隆版。碎片从顶部落下游戏区域的位置，您可以水平移动它们以及旋转它们在他们到达游乐区底部之前。目标是打造完整 线片，然后将其移除。当堆栈到达时游戏结束的棋子到达游戏区域的顶部。

Log: finish app gottet.

![2ced9c06624dd0fcea4b402d062b0b9b](https://github.com/linuxdeepin/linglong-hub/assets/115330610/76e61a39-581b-4cbd-8e70-c67ca8442f19)
