### PR TITLE
build: add app connectagram

### DIFF
--- a/io.github.connectagram/linglong.yaml
+++ b/io.github.connectagram/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.connectagram
+  name: connectagram
+  version: 1.3.0
+  kind: app
+  description: |
+    Connectagram is a word unscrambling game. The board consists of several scrambled words that are joined together.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/gottcode/connectagram.git
+  commit: 317949fc46b4d5accbdc66cad1c5baca48edb2c3
+
+
+build:
+  kind: qmake
+


### PR DESCRIPTION
Connectagram 是一款单词解读游戏。由几位成员组成连接在一起的乱序单词。您可以选择长度单词、单词数量以及单词排列方式 游戏为您遇到困难时提供提示选项，并且具有在线单词查找功能，可获取每个单词的定义来自维基词典。您当前的进度会自动保存。

Log: finsih app connectagram.

![081353d477c57b781b1b4c867d9afca8](https://github.com/linuxdeepin/linglong-hub/assets/115330610/01b76c4d-5568-47f4-aa3c-cc21d95badfd)
