### PR TITLE
build: add app wtools-client

### DIFF
--- a/io.github.wtools-client/linglong.yaml
+++ b/io.github.wtools-client/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.wtools-client
+  name: wtools-client
+  version: 1.0.0
+  kind: app
+  description: |
+    Qt client for wtools. WTools is a software tool created by FWTools that provides users with a suite of command line tools for manipulating geospatial data.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/dridk/wtools-client.git
+  commit: fc39ebc681a462435836da6481ac2452d7e751b8
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake

--- a/io.github.wtools-client/patches/fix-001.patch
+++ b/io.github.wtools-client/patches/fix-001.patch
@@ -1,0 +1,25 @@
+--- ../wtools-gui.pro	2023-11-30 19:02:54.755162000 +0800
++++ ../wtools-gui.pro	2023-11-30 19:07:06.267665012 +0800
+@@ -39,3 +39,22 @@
+ 
+ RESOURCES += \
+     icons.qrc
++
++# desktop指定
++DESKTOP_FILE = ./wtools-gui.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=wtools-gui' >> $$DESKTOP_FILE")
++system("echo 'Comment=wtools-gui.' >> $$DESKTOP_FILE")
++system("echo 'Exec=$$PREFIX/bin/wtools-gui' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++# bin文件指定
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION
wtools 的 Qt 客户端.WTools 是 FWTools 创建的软件工具，为用户提供一套用于操作地理空间数据的命令行工具.

Log: finish app wtools-client.

![d62c123ef3df6f15ee3bb73bf5ae3a27](https://github.com/linuxdeepin/linglong-hub/assets/115330610/3625f8b0-ca3b-4786-aef5-6dc0120631e4)
