### PR TITLE
build: add app gravastre

### DIFF
--- a/io.github.gravastre/linglong.yaml
+++ b/io.github.gravastre/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.gravastre
+  name: gravastre
+  version: 1.0.0
+  kind: app
+  description: |
+    Gravastre is a gravitationnal simulation where all agents (named Astres) interacts, no matter there distance or their mass. The Qt interface allow user to see and play with the simulation during the computations.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/Aluriak/gravastre.git
+  commit: e7f98b5a59636b562f3314033699216b8ad85944
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.gravastre/patches/fix-001.patch
+++ b/io.github.gravastre/patches/fix-001.patch
@@ -1,0 +1,24 @@
+--- ../gravastre.pro	2023-12-01 10:52:48.304093000 +0800
++++ ../gravastre.pro	2023-12-01 10:54:54.539894210 +0800
+@@ -31,3 +31,21 @@
+     src/jsonConfig.h \
+     src/utils.h \
+     src/options.h
++
++DESKTOP_FILE = ./gravastre.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=gravastre' >> $$DESKTOP_FILE")
++system("echo 'Comment=gravastre.' >> $$DESKTOP_FILE")
++system("echo 'Exec=gravastre' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++


### PR DESCRIPTION
Gravastre 是一种引力模拟，所有星球（名为 Astres）都会相互作用，无论距离或质量如何。

最重要的是，其能添加新的星球，观察该星球的引力轨迹，用于学习与教学使用。

Log: finish app gravastre.

![16b6da1fc4ce2b6477f9f79fb12e3833](https://github.com/linuxdeepin/linglong-hub/assets/115330610/1a465719-5241-49b7-bbbb-4f38d0e1bc5a)
