### PR TITLE
build: add app QAbifReader

### DIFF
--- a/io.github.QAbifReader/linglong.yaml
+++ b/io.github.QAbifReader/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.QAbifReader
+  name: QAbifReader
+  version: 1.0.0
+  kind: app
+  description: |
+    QAbifReader is a Qt library to load data from an abif file following the specification of Abif file format. It allows you to read all content of ab1 and fsa file.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/dridk/QAbifReader.git
+  commit: 2c3881ece18e6d469d793c2c1657c58ca90d6a67
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.QAbifReader/patches/fix-001.patch
+++ b/io.github.QAbifReader/patches/fix-001.patch
@@ -1,0 +1,23 @@
+--- ../AbifReader.pro	2023-12-01 10:39:29.305459000 +0800
++++ ../AbifReader.pro	2023-12-01 10:43:40.701001606 +0800
+@@ -22,3 +22,20 @@
+     abifmodel.h
+ 
+ FORMS    += mainwindow.ui
++
++DESKTOP_FILE = ./AbifReader.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=AbifReader' >> $$DESKTOP_FILE")
++system("echo 'Comment=AbifReader.' >> $$DESKTOP_FILE")
++system("echo 'Exec=AbifReader' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION
QAbifReader 是用于按照 Abif 文件格式规范从 abif 文件加载数据。它允许您读取 ab1 和 fsa 文件的所有内容。

Log: finish app QAbifReader.

![c30af06dd9a73a663e0bce93b3bb3597](https://github.com/linuxdeepin/linglong-hub/assets/115330610/78044d40-23f8-4295-bdfa-bdf496a847bc)
