### PR TITLE
build: add app kmeter

### DIFF
--- a/io.github.kmeter/linglong.yaml
+++ b/io.github.kmeter/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.kmeter
+  name: kmeter
+  version: 1.0.0
+  kind: app
+  description: |
+    A free multiplatform (Linux/macOS/Windows) LP-100A virtual control panel.
+
+
+depends:
+  - id: qtserialport
+    version: 5.15.7
+    type: runtime
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/ea4k/kmeter.git
+  commit: 0d5e4e38a0ad68df06d3dbfe422df7dfde609fc0
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.kmeter/patches/fix-001.patch
+++ b/io.github.kmeter/patches/fix-001.patch
@@ -1,0 +1,23 @@
+--- ../KMeter.pro	2023-12-01 18:00:33.258648000 +0800
++++ ../KMeter.pro	2023-12-01 18:06:49.912070488 +0800
+@@ -177,3 +177,20 @@
+ {
+     TARGET = kmeter
+ }
++
++
++# desktop指定
++DESKTOP_FILE = ./kmeter.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=kmeter' >> $$DESKTOP_FILE")
++system("echo 'Comment=kmeter.' >> $$DESKTOP_FILE")
++system("echo 'Exec=kmeter' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++


### PR DESCRIPTION
免费的多平台（Linux/macOS/Windows）LP-100A 虚拟控制面板.

Log: finish app kmeter.

![fb1cc9fd058dd0d8b89f037119780291](https://github.com/linuxdeepin/linglong-hub/assets/115330610/9fb3a758-6a10-42d4-a2ce-d937043d6cb1)
