### PR TITLE
build: add app TASToolKitEditor

### DIFF
--- a/io.github.TASToolKitEditor/linglong.yaml
+++ b/io.github.TASToolKitEditor/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.TASToolKitEditor
+  name: TASToolKitEditor
+  version: 1.0.0
+  kind: app
+  description: |
+    A lightweight .csv visualizer/editor meant to assist in the development of Mario Kart Wii Tool-Assisted Speedruns.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/malleoz/TASToolKitEditor.git
+  commit: ccceb288d13c468f7b1dadb3bb48482fbccd4aa4
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+  

--- a/io.github.TASToolKitEditor/patches/fix-001.patch
+++ b/io.github.TASToolKitEditor/patches/fix-001.patch
@@ -1,0 +1,16 @@
+--- ../CMakeLists.txt	2023-12-02 13:55:41.119148000 +0800
++++ ../CMakeLists.txt	2023-12-02 13:55:50.359350142 +0800
+@@ -23,3 +23,13 @@
+ 
+ install(TARGETS TTKEditor)
+ 
++# 写入desktop
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=TTKEditor
++Exec=TTKEditor
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/TTKEditor.desktop "${DESKTOP_FILE_CONTENT}")
++


### PR DESCRIPTION
一个轻量级的 .csv 可视化工具/编辑器，旨在协助开发 Mario Kart Wii 工具辅助 Speedruns。使用 Qt 框架用 C++ 开发。

Log: finish TASToolKitEditor.

![cc7f203f73c7e7705d61e514a39bcaa3](https://github.com/linuxdeepin/linglong-hub/assets/115330610/ddf5fcd8-e3de-4b61-b727-0643edc44e8c)
