### PR TITLE
build: add app DecryptorQt

### DIFF
--- a/io.github.DecryptorQt/linglong.yaml
+++ b/io.github.DecryptorQt/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.DecryptorQt
+  name: DecryptorQt
+  version: 1.0.0
+  kind: app
+  description: |
+    Decryptor for DuckSharp and DuckCpp logs.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/zorggomat/DecryptorQt.git
+  commit: cc1b01140e587cd1cb9979d3163e364d6070eb61
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.DecryptorQt/patches/fix-001.patch
+++ b/io.github.DecryptorQt/patches/fix-001.patch
@@ -1,0 +1,35 @@
+--- ../DecryptorQt.pro	2023-12-02 20:49:54.690736000 +0800
++++ ../DecryptorQt.pro	2023-12-02 20:54:00.108086445 +0800
+@@ -32,7 +32,7 @@
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: target.path = $$PREFIX/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
+ DISTFILES += \
+@@ -40,3 +40,23 @@
+ 
+ RESOURCES += \
+     resources.qrc
++
++DESKTOP_FILE = ./FitbitActivitiesChart.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=DecryptorQt' >> $$DESKTOP_FILE")
++system("echo 'Comment=DecryptorQt.' >> $$DESKTOP_FILE")
++system("echo 'Exec=DecryptorQt' >> $$DESKTOP_FILE")
++system("echo 'Icon=duck.ico' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++icon.files = $$PWD/duck.ico
++icon.path = $$PREFIX/share/icons/DecryptorQt/
++INSTALLS += icon
++


### PR DESCRIPTION
用于解密 DuckCpp 和 DuckSharp 日志的简单 Qt 应用程序。

Log: finish app DecryptorQt.

![27f72c95eb4e514e3bd6088aa55da2f4](https://github.com/linuxdeepin/linglong-hub/assets/115330610/a55d4ec1-c450-43f6-b627-cea303f85539)
