### PR TITLE
build: add app dominant-colors-rgb-wheel

### DIFF
--- a/io.github.dominant-colors-rgb-wheel/linglong.yaml
+++ b/io.github.dominant-colors-rgb-wheel/linglong.yaml
@@ -1,0 +1,33 @@
+package:
+  id: io.github.dominant-colors-rgb-wheel
+  name: dominant-colors-rgb-wheel
+  version: 2.0.0
+  kind: app
+  description: |
+    Find dominant colors in images with QT and OpenCV, with a nice GUI to show results on a RGB wheel - Colors analysis includes color schemes, brightness and cool/warm distribution - All algorithms done in CIELab color space.
+
+
+depends:
+  - id: opencv
+    version: 4.8.1
+    type: runtime
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/AbsurdePhoton/dominant-colors-rgb-wheel.git
+  commit: a137b08345e878306f42e12bb12b3c8d55dee81b
+  patch: 
+    - patches/fix-001.patch
+    - patches/fix-002.patch
+    - patches/fix-003.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.dominant-colors-rgb-wheel/patches/fix-001.patch
+++ b/io.github.dominant-colors-rgb-wheel/patches/fix-001.patch
@@ -1,0 +1,19 @@
+--- ../mainwindow.cpp	2023-12-03 13:59:16.928620000 +0800
++++ ../mainwindow.cpp	2023-12-03 14:51:31.286258107 +0800
+@@ -20,6 +20,7 @@
+ #include <QPainter>
+ #include <QScrollBar>
+ #include <QWhatsThis>
++#include <QApplication>
+ 
+ #include <fstream>
+ 
+@@ -133,7 +134,7 @@
+     // read color names from .csv file
+     std::string line; // line to read in text file
+     std::ifstream names; // file to read
+-    names.open("color-names.csv"); // read color names file
++    names.open((QApplication::applicationDirPath() + "/color-names.csv").toStdString()); // read color names file
+ 
+     if (names) { // if successfully read
+         nb_color_names = -1; // index of color names array

--- a/io.github.dominant-colors-rgb-wheel/patches/fix-002.patch
+++ b/io.github.dominant-colors-rgb-wheel/patches/fix-002.patch
@@ -1,0 +1,11 @@
+--- ../mat-image-tools.cpp	2023-12-03 13:59:16.928620000 +0800
++++ ../mat-image-tools.cpp	2023-12-03 14:11:56.930334269 +0800
+@@ -21,6 +21,8 @@
+ 
+ #include <QPixmap>
+ 
++#include <fstream>
++
+ #include "opencv2/opencv.hpp"
+ 
+ #include "mat-image-tools.h"

--- a/io.github.dominant-colors-rgb-wheel/patches/fix-003.patch
+++ b/io.github.dominant-colors-rgb-wheel/patches/fix-003.patch
@@ -1,0 +1,29 @@
+--- ../dominant-colors-rgb-wheel.pro	2023-12-03 14:55:38.387033921 +0800
++++ ../dominant-colors-rgb-wheel.pro	2023-12-03 14:36:08.835216172 +0800
+@@ -42,3 +42,26 @@
+ RESOURCES += resources.qrc
+ 
+ CONFIG += c++11
++
++
++csv_file.files = /source/color-names.csv
++csv_file.path = $$PREFIX/bin
++INSTALLS += csv_file
++
++DESKTOP_FILE = ./dominant-colors-rgb-wheel.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=dominant-colors-rgb-wheel' >> $$DESKTOP_FILE")
++system("echo 'Comment=dominant-colors-rgb-wheel.' >> $$DESKTOP_FILE")
++system("echo 'Exec=dominant-colors-rgb-wheel' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files = $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++


### PR DESCRIPTION
使用 QT 和 OpenCV 查找图像中的主色，并通过漂亮的 GUI 在 RGB 轮上显示结果 - 颜色分析包括配色方案、亮度和冷/暖分布 - 所有算法均在 CIELab 颜色空间中完成。

Log: finish app dominant-colors-rgb-wheel.

![34a69dec443baa5b150f29033d298dbe](https://github.com/linuxdeepin/linglong-hub/assets/115330610/65c69153-bddb-4452-9cfa-87b4504d7c5d)
