### PR TITLE
build: add app calib-mpo

### DIFF
--- a/io.github.calib-mpo/linglong.yaml
+++ b/io.github.calib-mpo/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.calib-mpo
+  name: calib-mpo
+  version: 1.0.0
+  kind: app
+  description: |
+    3D stereo camera calibration with QT and openCV, using stereo pairs (PNG, TIF, JPG, etc) or stereo MPO images.
+
+
+depends:
+  - id: opencv
+    version: 4.8.1
+    type: runtime
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/AbsurdePhoton/calib-mpo.git
+  commit: 2e7b56d7d72440342ec3081d458d70907d170d9f
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.calib-mpo/patches/fix-001.patch
+++ b/io.github.calib-mpo/patches/fix-001.patch
@@ -1,0 +1,23 @@
+--- ../calib-mpo-opencv.pro	2023-12-03 15:48:14.482340000 +0800
++++ ../calib-mpo-opencv.pro	2023-12-03 15:51:42.897288038 +0800
+@@ -36,3 +36,20 @@
+ 
+ # icons
+ RESOURCES += resources.qrc
++
++DESKTOP_FILE = ./calib-mpo-opencv.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=calib-mpo-opencv' >> $$DESKTOP_FILE")
++system("echo 'Comment=calib-mpo-opencv.' >> $$DESKTOP_FILE")
++system("echo 'Exec=calib-mpo-opencv' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target


### PR DESCRIPTION
使用 QT 和 openCV，使用立体对（PNG、TIF、JPG 等）或立体 MPO 图像进行 3D 立体相机校准。

Log: finish app calib-map.

![e4102b04802c71de4a0dbc74e1fbd94d](https://github.com/linuxdeepin/linglong-hub/assets/115330610/49b926a7-3698-4e30-9269-9db89632ff80)
