### PR TITLE
build: add app neural-style-jcjohnson-gui

### DIFF
--- a/io.github.neural-style-jcjohnson-gui/linglong.yaml
+++ b/io.github.neural-style-jcjohnson-gui/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.neural-style-jcjohnson-gui
+  name: neural-style-jcjohnson-gui
+  version: 1.0.0
+  kind: app
+  description: |
+    neural-style is a stunning piece of code, which can apply a style (e.g. Picasso, Van Gogh, whatever you choose) to your photos. For that, it uses A.I., more precisely convolutional neural networks. An implementation of neural style with Torch by jcjohnson: https://github.com/jcjohnson/neural-style.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/AbsurdePhoton/neural-style-jcjohnson-gui.git
+  commit: ec4c5c8f53aaf8e75dc84cecbce099248be88c27
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.neural-style-jcjohnson-gui/patches/fix-001.patch
+++ b/io.github.neural-style-jcjohnson-gui/patches/fix-001.patch
@@ -1,0 +1,25 @@
+--- ../neural-style.pro	2023-12-03 15:26:59.005466000 +0800
++++ ../neural-style.pro	2023-12-03 15:30:04.630063517 +0800
+@@ -20,3 +20,22 @@
+ HEADERS  += mainwindow.h
+ 
+ FORMS    += mainwindow.ui
++
++
++DESKTOP_FILE = ./neural-style.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.0.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=neural-style' >> $$DESKTOP_FILE")
++system("echo 'Comment=neural-style.' >> $$DESKTOP_FILE")
++system("echo 'Exec=neural-style' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++


### PR DESCRIPTION
neural-style 是一段令人惊叹的代码，它可以将一种风格（例如毕加索、梵高，无论你选择什么）应用于你的照片。为此，它使用人工智能，更准确地说是卷积神经网络。 jcjohnson 使用 Torch 实现神经风格：https://github.com/jcjohnson/neural-style。 注意：需要你的计算机本地拥有torch库与对应cnn模型。

Log: finish app neural-style-jcjohnson-gui.

![f689083f294a4c71e7aecc122eedf498](https://github.com/linuxdeepin/linglong-hub/assets/115330610/2aadaddd-e0f8-42cb-915f-2cd921836a59)
