### PR TITLE
build: add app segmentation-depthmap-3d-opencv

### DIFF
--- a/io.github.segmentation-depthmap-3d-opencv/linglong.yaml
+++ b/io.github.segmentation-depthmap-3d-opencv/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.segmentation-depthmap-3d-opencv
+  name: segmentation-depthmap-3d-opencv
+  version: 1.5.0
+  kind: app
+  description: |
+    Use an image segmentation to produce a RGB+D image (image + depthmap). Or use the GUI to view already-made RGB+D images in 3D, there's even an anaglyph mode to perceive depth with red+cyan glasses. Animate the 3D view and export to a series of images to build later an animated image. This nice GUI uses QT, OpenCV and OpenGL.
+
+
+depends:
+  - id: opencv
+    version: 4.8.1
+    type: runtime
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/AbsurdePhoton/segmentation-depthmap-3d-opencv.git
+  commit: 4e7920464e2bb9690e42dec6fdce66634b9390f9
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: qmake
+

--- a/io.github.segmentation-depthmap-3d-opencv/patches/fix-001.patch
+++ b/io.github.segmentation-depthmap-3d-opencv/patches/fix-001.patch
@@ -1,0 +1,24 @@
+--- ../segmentation-depthmap-3d-opencv.pro	2023-12-03 18:01:42.813118000 +0800
++++ ../segmentation-depthmap-3d-opencv.pro	2023-12-03 18:06:36.681862374 +0800
+@@ -38,3 +38,21 @@
+ 
+ # icons
+ RESOURCES += resources.qrc
++
++DESKTOP_FILE = ./segmentation-depthmap-3d-opencv.desktop
++system("echo '[Desktop Entry]' > $$DESKTOP_FILE")
++system("echo 'Version=1.5.0' >> $$DESKTOP_FILE")
++system("echo 'Type=Application' >> $$DESKTOP_FILE")
++system("echo 'Name=segmentation-depthmap-3d-opencv' >> $$DESKTOP_FILE")
++system("echo 'Comment=segmentation-depthmap-3d-opencv.' >> $$DESKTOP_FILE")
++system("echo 'Exec=segmentation-depthmap-3d-opencv' >> $$DESKTOP_FILE")
++system("echo 'Terminal=false' >> $$DESKTOP_FILE")
++system("echo 'Categories=Utility;' >> $$DESKTOP_FILE")
++
++desktop.files += $$DESKTOP_FILE
++desktop.path = $$PREFIX/share/applications
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++


### PR DESCRIPTION
使用图像分割生成 RGB+D 图像（图像 + 深度图）。或者使用 GUI 以 3D 方式查看已制作的 RGB+D 图像，甚至还有浮雕模式，可以使用红+青色眼镜感知深度。对 3D 视图进行动画处理并导出为一系列图像，以便稍后构建动画图像。这个漂亮的 GUI 使用 QT、OpenCV 和 OpenGL。

Log: finish app segmentation-depthmap-3d-opencv.

![c99cf7d4dbd4299fee85d112a81b660a](https://github.com/linuxdeepin/linglong-hub/assets/115330610/ef0bc225-a787-49af-b14a-2d055d1c3e78)
