### PR TITLE
build: add app FrankfurterDesktop

### DIFF
--- a/io.github.FrankfurterDesktop/linglong.yaml
+++ b/io.github.FrankfurterDesktop/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.FrankfurterDesktop
+  name: FrankfurterDesktop
+  version: 0.0.1
+  kind: app
+  description: |
+    App to view currency exchange rate from European Currence Exchange.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/asit-dhal/FrankfurterDesktop.git
+  commit: 6d250175c4f161037436e318b0aaffaa8c1c2f0c
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+

--- a/io.github.FrankfurterDesktop/patches/fix-001.patch
+++ b/io.github.FrankfurterDesktop/patches/fix-001.patch
@@ -1,0 +1,20 @@
+--- ../CMakeLists.txt	2023-12-03 20:15:05.171736000 +0800
++++ ../CMakeLists.txt	2023-12-03 20:32:23.870472616 +0800
+@@ -61,3 +61,17 @@
+     juce::juce_gui_basics
+     nlohmann_json::nlohmann_json
+ )
++
++# 写入desktop
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=FrankfurterDesktop
++Exec=FrankfurterDesktop
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/FrankfurterDesktop.desktop "${DESKTOP_FILE_CONTENT}")
++# 写入bin文件
++install(TARGETS FrankfurterDesktop DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++
++


### PR DESCRIPTION
用于查看欧洲货币兑换的货币汇率的应用程序。

Log: finish app FranfurterDesktop.

![cdc87266322a4c6b50617c3ce9e68ada](https://github.com/linuxdeepin/linglong-hub/assets/115330610/68f45fb5-a152-4204-a3cf-f354b2167e96)
