### PR TITLE
build: add app BenchmarkViewer

### DIFF
--- a/io.github.BenchmarkViewer/linglong.yaml
+++ b/io.github.BenchmarkViewer/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.BenchmarkViewer
+  name: BenchmarkViewer
+  version: 1.0.0
+  kind: app
+  description: |
+    Qt application to view Google Microbenchmarking data https://github.com/google/benchmark.
+
+
+depends:
+  - id: qtcharts
+    version: 5.15.7
+    type: runtime
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/asit-dhal/BenchmarkViewer.git
+  commit: 52d4943936f963d120ca449ce8887eab19aab931
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+

--- a/io.github.BenchmarkViewer/patches/fix-001.patch
+++ b/io.github.BenchmarkViewer/patches/fix-001.patch
@@ -1,0 +1,16 @@
+--- ../app/CMakeLists.txt	2023-12-04 09:32:39.453861000 +0800
++++ ../app/CMakeLists.txt	2023-12-04 09:37:16.774586759 +0800
+@@ -61,3 +61,13 @@
+                     Qt5::Charts
+                     )
+ 
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=BenchmarkViewer
++Exec=BenchmarkViewer
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/BenchmarkViewer.desktop "${DESKTOP_FILE_CONTENT}")
++install(TARGETS BenchmarkViewer DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++


### PR DESCRIPTION
用于查看 Google Microbenchmarking 数据的 Qt 应用程序 https://github.com/google/benchmark。

Log: finish app BenchmarkViewer.

![793d0c7ff29523e2f72f7ec4e0e5c65b](https://github.com/linuxdeepin/linglong-hub/assets/115330610/e5a4c1b2-364a-4a40-bafb-351980bc2bf9)
