### PR TITLE
build: add io.github.daykountdown

### DIFF
--- a/io.github.daykountdown/linglong.yaml
+++ b/io.github.daykountdown/linglong.yaml
@@ -1,0 +1,48 @@
+package:
+  id: io.github.daykountdown
+  name: daykountdown 
+  version: 0.0.1
+  kind: app
+  description: |
+     A date countdown app written in QML/Kirigami and C++, for use with KDE Plasma on Linux.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: kglobalaccel/5.90.0
+  - id: kio/5.90.0
+  - id: kirigami/5.90.0
+  - id: kjobwidgets/5.90.0
+  - id: sonnet/5.90.0
+  - id: ktextwidgets/5.90.0
+  - id: kxmlgui/5.90.0
+  - id: kcodecs/5.90.0
+  - id: kauth/5.90.0
+  - id: kbookmarks/5.90.0
+  - id: solid/5.90.0
+  - id: karchive/5.90.0
+  - id: kconfig/5.90.0
+  - id: kcrash/5.90.0
+  - id: ki18n/5.90.0
+  - id: kservice/5.90.0
+  - id: kbookmarks/5.90.0
+  - id: kcompletion/5.90.0
+  - id: kitemviews/5.90.0
+  - id: kiconthemes/5.90.0
+  - id: kguiaddons/5.90.0
+  - id: kconfigwidgets/5.90.0
+  - id: kcompletion/5.90.0
+  - id: kdbusaddons/5.90.0
+  - id: kwidgetsaddons/5.90.0
+  - id: kcoreaddons/5.90.0
+  - id: kwindowsystem/5.90.0
+
+
+source:
+  kind: git
+  url: https://github.com/KDE/daykountdown.git
+  commit: 357fb6d6b8d752a24aa07fd22e8661da43c5166d
+
+build:
+  kind: cmake


### PR DESCRIPTION
 
![截图_deepin-terminal_20231209162903](https://github.com/linuxdeepin/linglong-hub/assets/84424520/7044f1a1-5a0f-44bf-8c82-b446e2267fcf)

A date countdown app written in QML/Kirigami and C++, for use with KDE Plasma on Linux.

log: add app