### PR TITLE
build: add app lovi

### DIFF
--- a/io.github.lovi/linglong.yaml
+++ b/io.github.lovi/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.lovi
+  name: lovi
+  version: 1.0.0
+  kind: app
+  description: |
+    Lovi is a log file viewer. Lovi works by splitting log files in columns, and colorizing certain lines or cells, depending on user-defined highlights.
+
+
+depends:
+  - id: kguiaddons
+    version: 5.90.0
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/agateau/lovi.git
+  commit: 2327fba60dee52819142a22351a7d6ae26f54577
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake

--- a/io.github.lovi/patches/fix-001.patch
+++ b/io.github.lovi/patches/fix-001.patch
@@ -1,0 +1,28 @@
+--- ../third-party/catch2/catch.hpp	2023-12-04 10:27:55.317066000 +0800
++++ ../third-party/catch2/catch.hpp	2023-12-04 11:08:11.870695270 +0800
+@@ -10788,7 +10788,7 @@
+ 
+     // 32kb for the alternate stack seems to be sufficient. However, this value
+     // is experimentally determined, so that's not guaranteed.
+-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
++    static const std::size_t sigStackSize=32768;
+ 
+     static SignalDefs signalDefs[] = {
+         { SIGINT,  "SIGINT - Terminal interrupt signal" },
+@@ -10813,6 +10813,7 @@
+     }
+ 
+     FatalConditionHandler::FatalConditionHandler() {
++
+         isSet = true;
+         stack_t sigStack;
+         sigStack.ss_sp = altStackMem;
+@@ -10844,6 +10845,8 @@
+         }
+     }
+ 
++    // 在类外初始化静态成员变量
++//    std::size_t Catch::FatalConditionHandler::sigStackSize; // 注意：这里不再是 constexpr
+     bool FatalConditionHandler::isSet = false;
+     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
+     stack_t FatalConditionHandler::oldSigStack = {};


### PR DESCRIPTION
Lovi 是一个日志文件查看器。 Lovi 的工作原理是将日志文件拆分为列，并根据用户定义的突出显示对某些行或单元格进行着色。

Log: finish app lovi.

![23ee97047e14bd107a4b62fe5e620edd](https://github.com/linuxdeepin/linglong-hub/assets/115330610/c11dc35e-5f6f-4354-8c55-37120fb2d7a6)
