### PR TITLE
build: add marknote

### DIFF
--- a/io.github.marknote/linglong.yaml
+++ b/io.github.marknote/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.marknote
+  name: marknote 
+  version: 0.0.1
+  kind: app
+  description: |
+     A simple markdown note management app
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+
+  - id: kirigami/5.90.0
+  - id: kconfig/5.90.0
+  - id: ki18n/5.90.0
+
+
+
+source:
+  kind: git
+  url: https://github.com/KDE/marknote.git
+  commit: 33a2faf9b1838e02d04c783b2da28e4602146ee6
+
+build:
+  kind: cmake


### PR DESCRIPTION

![截图_deepin-terminal_20231209164202](https://github.com/linuxdeepin/linglong-hub/assets/84424520/dce5fa17-095e-4e29-937c-e8268a7efe0c)



A simple markdown note management app.

log: add app