### PR TITLE
build: add app QMidiPlayer

### DIFF
--- a/io.github.QMidiPlayer/linglong.yaml
+++ b/io.github.QMidiPlayer/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.QMidiPlayer
+  name: QMidiPlayer
+  version: 0.8.7
+  kind: app
+  description: |
+    A cross-platform midi file player based on libfluidsynth and Qt.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: fluidsynth
+    version: 2.3.4
+  - id: glfw/3.3.8
+  - id: rtmidi
+    version: 4.0.0
+
+variables:
+  extra_args: |
+    -DBUILD_VISUALIZATION=OFF
+
+source:
+  kind: git
+  url: https://github.com/chirs241097/QMidiPlayer.git
+  commit: 07ee50be7c390668f8c600b8eb5805f56cf6a8a1
+  patch: patches/fix-001.patch
+
+build:
+  kind: cmake
+

--- a/io.github.QMidiPlayer/patches/fix-001.patch
+++ b/io.github.QMidiPlayer/patches/fix-001.patch
@@ -1,0 +1,26 @@
+--- ../qmidiplayer-desktop/CMakeLists.txt	2023-11-02 19:31:16.941820000 +0800
++++ ../qmidiplayer-desktop/CMakeLists.txt	2023-12-02 10:21:16.885672486 +0800
+@@ -98,9 +98,22 @@
+ install(DIRECTORY ${PROJECT_SOURCE_DIR}/doc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/qmidiplayer)
+ install(DIRECTORY ${PROJECT_SOURCE_DIR}/img DESTINATION ${CMAKE_INSTALL_PREFIX}/share/qmidiplayer FILES_MATCHING PATTERN "*.png")
+ install(FILES qmidiplayer.appdata.xml DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata)
+-install(FILES qmidiplayer.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
++# install(FILES qmidiplayer.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+ install(FILES ${PROJECT_SOURCE_DIR}/img/qmidiplyr.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/64x64/apps)
+ install(FILES ${PROJECT_SOURCE_DIR}/img/qmidiplyr.svg DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)
+ install(FILES menu/qmidiplayer DESTINATION ${CMAKE_INSTALL_PREFIX}/share/menu)
+ install(FILES qmidiplayer.mime DESTINATION ${CMAKE_INSTALL_PREFIX}/share/mime/packages)
+ install(FILES ${qmpdesktop_QM_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/qmidiplayer/translations)
++
++# 写入desktop
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=qmidiplayer
++Exec=qmidiplayer
++Icon=qmidiplyr
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/qmidiplayer.desktop "${DESKTOP_FILE_CONTENT}")
++
++


### PR DESCRIPTION
基于 libfluidsynth 和 Qt 的跨平台 midi 文件播放器。

Log: finish app QMidiPlayer.

![91236ab278947e50fcc35357ed119a1b](https://github.com/linuxdeepin/linglong-hub/assets/115330610/fb47a528-4a6f-4f02-a612-47157d69f167)
