### PR TITLE
build: add app ganman

### DIFF
--- a/io.github.ganman/linglong.yaml
+++ b/io.github.ganman/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.ganman
+  name: ganman
+  version: 0.7.0
+  kind: app
+  description: |
+    Simple and multi-platform screen/camera capture.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/CharNoe/ganman.git
+  commit: 683500b0b282f60938ac93b132bdac2f3992b135
+  patch: 
+    - patches/fix-001.patch
+    - patches/fix-002.patch
+    - patches/fix-003.patch
+
+
+build:
+  kind: cmake
+ 

--- a/io.github.ganman/patches/fix-001.patch
+++ b/io.github.ganman/patches/fix-001.patch
@@ -1,0 +1,16 @@
+--- ../CMakeLists.txt	2023-12-08 11:15:26.804844000 +0800
++++ ../CMakeLists.txt	2023-12-08 11:27:32.357540099 +0800
+@@ -28,3 +28,13 @@
+     Ganman
+     PRIVATE Qt5::Widgets Qt5::Multimedia
+     )
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=Ganman
++Exec=Ganman
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/Ganman.desktop "${DESKTOP_FILE_CONTENT}")
++install(TARGETS Ganman DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/io.github.ganman/patches/fix-002.patch
+++ b/io.github.ganman/patches/fix-002.patch
@@ -1,0 +1,8 @@
+--- ../src/CaptureDisplay.h	2023-12-08 11:15:26.808844000 +0800
++++ ../src/CaptureDisplay.h	2023-12-08 11:34:16.152608572 +0800
+@@ -1,3 +1,5 @@
++#include <memory>
++
+ #pragma once
+ 
+ #include "CaptureBase.h"

--- a/io.github.ganman/patches/fix-003.patch
+++ b/io.github.ganman/patches/fix-003.patch
@@ -1,0 +1,8 @@
+--- ../src/ImageListModel.h	2023-12-08 11:15:26.808844000 +0800
++++ ../src/ImageListModel.h	2023-12-08 11:33:37.864653783 +0800
+@@ -1,3 +1,5 @@
++#include <memory>
++
+ #pragma once
+ 
+ #include <QAbstractListModel>


### PR DESCRIPTION
简单且多平台的屏幕/相机捕获的工具.

Log: finish app ganman.

![de8f685fea53acb619fef6ad6737f6ec](https://github.com/linuxdeepin/linglong-hub/assets/115330610/adf000ed-32db-4486-bc11-6938e290ebd0)
