### PR TITLE
build: add app TileData-Editor

### DIFF
--- a/io.github.TileData-Editor/linglong.yaml
+++ b/io.github.TileData-Editor/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.TileData-Editor
+  name: TileData-Editor
+  version: 1.4.0
+  kind: app
+  description: |
+    The editor for the TileData.json used by Cytopia. Cytopia: https://github.com/CytopiaTeam/Cytopia.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/CytopiaTeam/TileData-Editor.git
+  commit: 9ededb2748e200fbf513a9e6a3ffde98ce4b6730
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+ 

--- a/io.github.TileData-Editor/patches/fix-001.patch
+++ b/io.github.TileData-Editor/patches/fix-001.patch
@@ -1,0 +1,30 @@
+--- ../CMakeLists.txt	2023-12-08 16:14:34.283730000 +0800
++++ ../CMakeLists.txt	2023-12-08 16:22:49.650337145 +0800
+@@ -2,9 +2,9 @@
+ cmake_policy(SET CMP0087 NEW)
+ 
+ # setup paths
+-SET(RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+-SET(LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/")
+-SET(ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/")
++SET(RUNTIME_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}/bin/")
++SET(LIBRARY_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/")
++SET(ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/")
+ SET(EXECUTABLE_OUTPUT_PATH ${RUNTIME_OUTPUT_DIRECTORY})
+ SET(LIBRARY_OUTPUT_PATH ${RUNTIME_OUTPUT_DIRECTORY})
+ # fix executable paths for windows
+@@ -86,3 +86,14 @@
+     install(CODE "execute_process(COMMAND ${QT_BIN_DIR}/windeployqt.exe $<TARGET_FILE:${PROJECT_NAME}> --release --no-compiler-runtime --no-translations --no-opengl-sw --dir \${CMAKE_INSTALL_PREFIX})")
+ 
+ endif()
++
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=TileDataEditor
++Exec=TileDataEditor
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/TileDataEditor.desktop "${DESKTOP_FILE_CONTENT}")
++# install(TARGETS TileDataEditor DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)


### PR DESCRIPTION
Cytopia软件中，为其 TileData.json完成快速编辑的编辑器工具。

Log: finish app TileData-Editor.

![a1273cfb76b9a3bb40c33ad1986442eb](https://github.com/linuxdeepin/linglong-hub/assets/115330610/e859029b-dad8-4d7a-9258-83bd7332826f)
