### PR TITLE
build: add app EZP2019-EZP2025_chip_data_editor

### DIFF
--- a/io.github.EZP2019-EZP2025_chip_data_editor/linglong.yaml
+++ b/io.github.EZP2019-EZP2025_chip_data_editor/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.EZP2019-EZP2025_chip_data_editor
+  name: EZP2019-EZP2025_chip_data_editor
+  version: 1.0.0
+  kind: app
+  description: |
+    QT based editor chip database for EZP2019, EZP2019+, EZP2020, EZP2023, EZP2025, MinPro, XP866+, MinproI programmer devices.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/bigbigmdm/EZP2019-EZP2025_chip_data_editor.git
+  commit: 2ca0977a0523103dde7d22afc94a711025ab322f
+  patch: patches/fix-001.patch
+
+
+build:
+  kind: cmake
+ 

--- a/io.github.EZP2019-EZP2025_chip_data_editor/patches/fix-001.patch
+++ b/io.github.EZP2019-EZP2025_chip_data_editor/patches/fix-001.patch
@@ -1,0 +1,25 @@
+--- ../CMakeLists.txt	2023-12-08 16:32:08.872629000 +0800
++++ ../CMakeLists.txt	2023-12-08 16:43:50.884656205 +0800
+@@ -33,8 +33,17 @@
+ target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+ 
+ 
+-install(TARGETS ${PROJECT_NAME} DESTINATION /opt/ezp_editor)
+-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/other/ezp_editor.desktop" DESTINATION /opt/ezp_editor)
+-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/other/ezp_editor.desktop" DESTINATION /usr/share/applications)
+-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/img/chipEdit64.png" DESTINATION /opt/ezp_editor)
+-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/languages/chipEditor_ru_RU.qm" DESTINATION /opt/ezp_editor/languages)
++install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++# install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/other/ezp_editor.desktop" DESTINATION ${CMAKE_INSTALL_PREFIX}/ezp_editor)
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=ezp_editor
++Exec=ezp_editor
++Icon='chipEdit64.png'
++Categories=Utility;
++")
++file(WRITE ${CMAKE_INSTALL_PREFIX}/share/applications/ezp_editor.desktop "${DESKTOP_FILE_CONTENT}")
++# install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/other/ezp_editor.desktop" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
++install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/img/chipEdit64.png" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/ezp_editor)
++install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/languages/chipEditor_ru_RU.qm" DESTINATION ${CMAKE_INSTALL_PREFIX}/ezp_editor/languages)


### PR DESCRIPTION
基于 QT 的编辑器芯片数据库，适用于 EZP2019、EZP2019+、EZP2020、EZP2023、EZP2025、MinPro、XP866+、MinproI 编程器设备。

Log: finish app EZP2019-EZP2025_chip_data_editor.

![5adf9432e0b8e587ab45b09776aadd7a](https://github.com/linuxdeepin/linglong-hub/assets/115330610/ea0573dd-d5c9-47f7-9267-ee73a82c3860)
