### PR TITLE
build: add tagberry

### DIFF
--- a/io.github.tagberry/linglong.yaml
+++ b/io.github.tagberry/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.tagberry
+  name: tagberry
+  version: 0.0.1
+  kind: app
+  description: |
+    Tag-oriented Qt5 desktop calendar, task manager, and todo list.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/gavv/tagberry.git
+  commit: b83ca1b734dad955aafdc8189ecc0339e3c87528
+
+build:
+  kind: cmake


### PR DESCRIPTION
Finish build tagberry for ll-build

Log: 完成tagberry的编译

![1702131320020](https://github.com/linuxdeepin/linglong-hub/assets/150589759/6c02fbe9-8ac5-4f6d-8709-428fd5175df6)
