### PR TITLE
build: add 121gw-qt5

### DIFF
--- a/io.github.121gw-qt5/linglong.yaml
+++ b/io.github.121gw-qt5/linglong.yaml
@@ -1,0 +1,18 @@
+package:
+  id: io.github.121gw-qt5
+  name: 121gw-qt5
+  version: 1.0.0
+  kind: app
+  description: |
+    A Qt5 based application for the 121GW BLE enabled multimeter 
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "git@github.com:zonque/121gw-qt5.git"
+  commit: 02f0d15
+  patch: patches/ab.patch
+build:
+  kind: qmake

--- a/io.github.121gw-qt5/patches/ab.patch
+++ b/io.github.121gw-qt5/patches/ab.patch
@@ -1,0 +1,20 @@
+diff -Naur b/121gw-qt5.desktop a/121gw-qt5.desktop
+--- b/121gw-qt5.desktop	1970-01-01 08:00:00.000000000 +0800
++++ a/121gw-qt5.desktop	2023-12-10 13:08:38.950780219 +0800
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Name=121gw-qt5
++Exec=121gw-qt5
++Type=Application
+diff -Naur b/121gw-qt5.pro a/121gw-qt5.pro
+--- b/121gw-qt5.pro	2023-12-10 13:07:29.198796553 +0800
++++ a/121gw-qt5.pro	2023-12-10 13:10:48.215494466 +0800
+@@ -44,3 +44,8 @@
+ 
+ RESOURCES += \
+     assets.qrc
++desktop.files += 121gw-qt5.desktop
++desktop.path = $${PREFIX}/share/applications
++target.path = $$(PREFIX)/bin
++
++INSTALLS += target desktop


### PR DESCRIPTION
Log: add app name--121gw-qt5
构建成功,缺少libQt5Bluetooth.so.5库本机run不出来
![图片](https://github.com/linuxdeepin/linglong-hub/assets/149229882/fd43b91a-21be-4d92-b76a-211e7f2bee3b)
