### PR TITLE
build: add Abstract-Games

### DIFF
--- a/com.gitlab.Abstract-Games/linglong.yaml
+++ b/com.gitlab.Abstract-Games/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: com.gitlab.Abstract-Games
+  name: Abstract-Games
+  version: 0.0.1
+  kind: app
+  description: |
+    A suite of classic arcade and board games.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://gitlab.com/abstractsoftware/abstract-games.git"
+  commit: 0e68adf4c3b28f134296fda1632051013e7cdd9e
+
+build:
+  kind: cmake


### PR DESCRIPTION

![com gitlab Abstract-Games_20231207170601](https://github.com/linuxdeepin/linglong-hub/assets/68770570/c47f87f0-13be-411d-b59b-8237ce28a36e)


Log: 完成Abstract-Games的编译