### PR TITLE
build: add Slacken

### DIFF
--- a/io.github.Slacken/linglong.yaml
+++ b/io.github.Slacken/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.Slacken
+  name: Slacken
+  version: 0.0.1
+  kind: app
+  description: |
+     Slacken, a lightweight Qt Slack client.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtnetworkauth/5.15.7
+    type: runtime
+
+
+source:
+  kind: git
+  url: https://github.com/pinaraf/Slacken.git
+  commit: 712a019a734327f724f05066c5ecd1a915826a38
+  patch: patches/0001-fix-install.patch
+ 
+build: 
+  kind: qmake

--- a/io.github.Slacken/patches/0001-fix-install.patch
+++ b/io.github.Slacken/patches/0001-fix-install.patch
@@ -1,0 +1,47 @@
+From 0e20d249c2b5768193f6c1557ae7a5741d3b07d8 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Mon, 11 Dec 2023 23:15:31 +0800
+Subject: [PATCH] fix-install
+
+---
+ Slacken.desktop |  8 ++++++++
+ Slacken.pro     | 11 +++++++++++
+ 2 files changed, 19 insertions(+)
+ create mode 100644 Slacken.desktop
+
+diff --git a/Slacken.desktop b/Slacken.desktop
+new file mode 100644
+index 0000000..857dba1
+--- /dev/null
++++ b/Slacken.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Exec=Slacken
++Name=Slacken
++Icon=base-icon.png
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/Slacken.pro b/Slacken.pro
+index dd427c9..b248f00 100644
+--- a/Slacken.pro
++++ b/Slacken.pro
+@@ -36,3 +36,14 @@ FORMS += \
+ 
+ RESOURCES += \
+     main.qrc
++
++#install role
++BINDIR  = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files = Slacken.desktop
++desktop.path = $$DATADIR/applications/
++icon.files=base-icon.png
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
++
+-- 
+2.33.1
+


### PR DESCRIPTION

![截图_选择区域_20231211232409](https://github.com/linuxdeepin/linglong-hub/assets/84424520/fa47606e-d382-4220-8270-0246aaab2dc4)

Slacken, a lightweight Qt Slack client.

log: add app