### PR TITLE
build: add Graph-Plotter

### DIFF
--- a/io.github.Graph-Plotter/linglong.yaml
+++ b/io.github.Graph-Plotter/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.Graph-Plotter
+  name: Graph-Plotter
+  version: 1.0.0
+  kind: app
+  description: |
+    A Graph Plotter desktop application in C++
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtscript/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/vaithak/Graph-Plotter.git
+  commit: 8e30fc2aa227b4e59f5a743850c042ee65e27f6e
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd Graph-plotter
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.Graph-Plotter/patches/0001-install.patch
+++ b/io.github.Graph-Plotter/patches/0001-install.patch
@@ -1,0 +1,45 @@
+From 114fbe19c80ce14684e7227195aa2348002899a8 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 9 Dec 2023 09:39:13 +0800
+Subject: [PATCH] install
+
+---
+ Graph-plotter/Graph-plotter.desktop | 8 ++++++++
+ Graph-plotter/Graph-plotter.pro     | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 Graph-plotter/Graph-plotter.desktop
+
+diff --git a/Graph-plotter/Graph-plotter.desktop b/Graph-plotter/Graph-plotter.desktop
+new file mode 100644
+index 0000000..6687134
+--- /dev/null
++++ b/Graph-plotter/Graph-plotter.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=Graph-plotter
++Name=Graph-plotter
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/Graph-plotter/Graph-plotter.pro b/Graph-plotter/Graph-plotter.pro
+index 51e3314..3eb40c1 100644
+--- a/Graph-plotter/Graph-plotter.pro
++++ b/Graph-plotter/Graph-plotter.pro
+@@ -32,3 +32,11 @@ HEADERS += \
+         mainwindow.h \
+     qcustomplot.h \
+     start_plotting.h
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =Graph-plotter.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    A Graph Plotter desktop application in C++

Log: add software name--Graph-Plotter
![Graph-Plotter](https://github.com/linuxdeepin/linglong-hub/assets/152461154/d7be6042-8919-449e-ba7e-8579d86f1941)
