### PR TITLE
build: add chart_system

### DIFF
--- a/io.github.chart_system/linglong.yaml
+++ b/io.github.chart_system/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.chart_system
+  name: chart_system
+  version: 0.0.1
+  kind: app
+  description: |
+    A GUI app displays binary file with chart
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtcharts/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/drewyh999/chart_system.git
+  commit: 029fe345707bc428578df1755f6f605abbd96d30
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.chart_system/patches/0001-install.patch
+++ b/io.github.chart_system/patches/0001-install.patch
@@ -1,0 +1,42 @@
+From 25bd1d5952a889f667227ec239e0a3b70937293b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 9 Dec 2023 12:01:14 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt                 | 4 +++-
+ build_dir/chart_system.desktop | 8 ++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+ create mode 100644 build_dir/chart_system.desktop
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 43c0043..fe2d796 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,4 +23,6 @@ target_link_libraries(
+         Qt5::Core
+         Qt5::Gui
+         Qt5::Charts
+-)
+\ No newline at end of file
++)
++install(PROGRAMS ${CMAKE_BINARY_DIR}/chart_system.desktop DESTINATION share/applications)
++install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+\ No newline at end of file
+diff --git a/build_dir/chart_system.desktop b/build_dir/chart_system.desktop
+new file mode 100644
+index 0000000..26ecc69
+--- /dev/null
++++ b/build_dir/chart_system.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=chart_system
++Name=chart_system
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+-- 
+2.33.1
+


### PR DESCRIPTION
    A GUI app displays binary file with chart

Log: add software name--chart_system
![chart_system](https://github.com/linuxdeepin/linglong-hub/assets/152461154/67950e5c-56d2-4dbb-aaff-2c1c2db80bd0)
