### PR TITLE
build: add SafeHaven

### DIFF
--- a/io.github.SafeHaven/linglong.yaml
+++ b/io.github.SafeHaven/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.SafeHaven
+  name: SafeHaven
+  version: 1.0.0
+  kind: app
+  description: |
+    A diary application built with the Qt5 library.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/adotrdot/SafeHaven.git
+  commit: 99f32facb713ede0b8fe3aa7372fc964cebf583a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.SafeHaven/patches/0001-install.patch
+++ b/io.github.SafeHaven/patches/0001-install.patch
@@ -1,0 +1,44 @@
+From 917249656c0246c5b1dddc8884dccdcefb395b23 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 10 Dec 2023 12:24:55 +0800
+Subject: [PATCH] install
+
+---
+ safehaven.desktop | 8 ++++++++
+ safehaven.pro     | 7 +++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 safehaven.desktop
+
+diff --git a/safehaven.desktop b/safehaven.desktop
+new file mode 100644
+index 0000000..3ea60e9
+--- /dev/null
++++ b/safehaven.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=safehaven
++Name=safehaven
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/safehaven.pro b/safehaven.pro
+index 424b156..f9f6564 100644
+--- a/safehaven.pro
++++ b/safehaven.pro
+@@ -39,3 +39,10 @@ QT += multimedia widgets
+ # Output
+ OBJECTS_DIR = .obj/
+ MOC_DIR = .moc/
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =safehaven.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+-- 
+2.33.1
+


### PR DESCRIPTION
    A diary application built with the Qt5 library.

Log: add software name--SafeHaven1
![SafeHaven](https://github.com/linuxdeepin/linglong-hub/assets/152461154/896f3691-379d-4ccc-a5c7-a9dcfa65429b)
