### PR TITLE
build: add Media-Player-Qt

### DIFF
--- a/io.github.Media-Player-Qt/linglong.yaml
+++ b/io.github.Media-Player-Qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.Media-Player-Qt
+  name: Media-Player-Qt
+  version: 0.2.0
+  kind: app
+  description: |
+    An open source media player built with Qt(C++)
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/stupid-kid-af/Media-Player-Qt.git
+  commit: 7e1eb40c1ae44359918b654adb583726cfd3eedf
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.Media-Player-Qt/patches/0001-install.patch
+++ b/io.github.Media-Player-Qt/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 8e5dd69b7423e386f4244521542c9bd1c2292bf5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 10 Dec 2023 12:29:41 +0800
+Subject: [PATCH] install
+
+---
+ mediaplayer.desktop | 9 +++++++++
+ mediaplayer.pro     | 9 +++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 mediaplayer.desktop
+
+diff --git a/mediaplayer.desktop b/mediaplayer.desktop
+new file mode 100644
+index 0000000..bc1a0bd
+--- /dev/null
++++ b/mediaplayer.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=mediaplayer
++Name=mediaplayer
++Icon=playicon
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/mediaplayer.pro b/mediaplayer.pro
+index 8744dae..0b9f273 100644
+--- a/mediaplayer.pro
++++ b/mediaplayer.pro
+@@ -27,3 +27,12 @@ RESOURCES += \
+ 
+ DISTFILES += \
+     icons/openicon.png
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =mediaplayer.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = icons/playicon.png
++icons.path = $$PREFIX/share/icons
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    An open source media player built with Qt(C++)

Log: add software name--Media-Player-Qt
![Media-Player-Qt](https://github.com/linuxdeepin/linglong-hub/assets/152461154/e1f14b27-c205-421e-9dcd-c47e4afa5f1d)
