### PR TITLE
build: add mano-simulator

### DIFF
--- a/io.github.mano-simulator/linglong.yaml
+++ b/io.github.mano-simulator/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.mano-simulator
+  name: mano-simulator
+  version: 1.3.1
+  kind: app
+  description: |
+    🖥️ An assembler and hardware simulator for the Mano Basic Computer, a 16 bit computer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/mmahdibarghi/mano-simulator.git
+  commit: 430b5d269e6fb63f0f5fa933fa754da75f7e7dc5
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+

--- a/io.github.mano-simulator/patches/0001-install.patch
+++ b/io.github.mano-simulator/patches/0001-install.patch
@@ -1,0 +1,55 @@
+From 73b28cba27d30072e57c7544add38acbff63ffb1 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 11 Dec 2023 18:41:50 +0800
+Subject: [PATCH] install
+
+---
+ manosimulator.desktop |  9 +++++++++
+ manosimulator.pro     | 11 +++++++++--
+ 2 files changed, 18 insertions(+), 2 deletions(-)
+ create mode 100644 manosimulator.desktop
+
+diff --git a/manosimulator.desktop b/manosimulator.desktop
+new file mode 100644
+index 0000000..76b1566
+--- /dev/null
++++ b/manosimulator.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=manosimulator
++Name=manosimulator
++Icon=icon
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/manosimulator.pro b/manosimulator.pro
+index f67a780..44b757c 100644
+--- a/manosimulator.pro
++++ b/manosimulator.pro
+@@ -27,7 +27,7 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
+ RESOURCES += \
+@@ -44,4 +44,11 @@ DISTFILES += \
+     saveasicon.png \
+     saveicon.png
+ win32:RC_ICONS += laptop.ico
+-
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =manosimulator.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = icon.png
++icons.path = $$PREFIX/share/icons
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    🖥️ An assembler and hardware simulator for the Mano Basic Computer, a 16 bit computer.

Log: add software name--mano-simulator
![mano-simulator](https://github.com/linuxdeepin/linglong-hub/assets/152461154/5d895e5c-e3cf-4f65-8e2a-3a81742633e6)
