### PR TITLE
build: add QBack

### DIFF
--- a/io.github.QBack/linglong.yaml
+++ b/io.github.QBack/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.QBack
+  name: QBack
+  version: 1.9.0
+  kind: app
+  description: |
+    A simple backup utility for Software and Hardware developers.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/GTRONICK/QBack.git
+  commit: 6dcc86eda9b09ef1ad946b1ad387a628ecdaced0
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.QBack/patches/0001-install.patch
+++ b/io.github.QBack/patches/0001-install.patch
@@ -1,0 +1,46 @@
+From fd7728978ccee71cfc34f951a0e96813053d5c11 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 11 Dec 2023 19:39:40 +0800
+Subject: [PATCH] install
+
+---
+ QBack.desktop | 9 +++++++++
+ QBack.pro     | 9 +++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 QBack.desktop
+
+diff --git a/QBack.desktop b/QBack.desktop
+new file mode 100644
+index 0000000..f5151b0
+--- /dev/null
++++ b/QBack.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=QBack
++Name=QBack
++Icon=log
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/QBack.pro b/QBack.pro
+index a8ee79a..077819e 100644
+--- a/QBack.pro
++++ b/QBack.pro
+@@ -33,3 +33,12 @@ RESOURCES += \
+     img/icons.qrc
+ 
+ win32:RC_ICONS += img/QBackLogo.ico
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =QBack.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = img/log.png
++icons.path = $$PREFIX/share/icons
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    A simple backup utility for Software and Hardware developers.

Log: add software name--QBack
![QBack](https://github.com/linuxdeepin/linglong-hub/assets/152461154/7362d7a1-929a-4008-8c26-73a28db1454d)
