### PR TITLE
build: add picta-dl-gui

### DIFF
--- a/io.github.picta-dl-gui/linglong.yaml
+++ b/io.github.picta-dl-gui/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.picta-dl-gui
+  name: picta-dl-gui
+  version: 0.12.28
+  kind: app
+  description: |
+    Picta Downloader GUI
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/oleksis/picta-dl-gui.git
+  commit: dee0de990ef94055fffdf83026b24164aa9c6a47
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Picta Downloader GUI

Log: add software name--picta-dl-gui
![picta-dl-gui](https://github.com/linuxdeepin/linglong-hub/assets/152461154/375b5357-8894-4cf5-99b6-041721743217)
