### PR TITLE
build: add screenshotgun

### DIFF
--- a/io.github.screenshotgun/linglong.yaml
+++ b/io.github.screenshotgun/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.screenshotgun
+  name: screenshotgun
+  version: 0.21.0
+  kind: app
+  description: |
+    Open cross-platform screenshoter with cloud support and server part
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ismd/screenshotgun.git
+  commit: 71a139c57c16cd12daf723ee9e1854b648031293
+
+build:
+  kind: cmake
+  


### PR DESCRIPTION
    Open cross-platform screenshoter with cloud support and server part

Log: add software name--screenshotgun
![screenshotgun](https://github.com/linuxdeepin/linglong-hub/assets/152461154/48fc622a-05dc-4f7a-a406-d7a8f05753ff)
