### PR TITLE
build: add app clawsker

### DIFF
--- a/io.github.clawsker/linglong.yaml
+++ b/io.github.clawsker/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.clawsker
+  name: clawsker
+  version: 1.3.7
+  kind: app
+  description:
+    Clawsker is a Perl-GTK2 applet to edit hidden preferences for Claws Mail, and to do it in a safe and user friendly way, preventing users from raw editing of configuration files.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: 'https://github.com/mones/clawsker.git'
+  version: master
+  commit: a6defb41bfbc13e6c588cd5da7bf648af508fbea
+
+build:
+  kind: manual
+  manual:
+      build: |
+        make 
+      install: |
+        make install


### PR DESCRIPTION
Log:add app name--clawsker, but it needs Glib module to run.
![image](https://github.com/linuxdeepin/linglong-hub/assets/125240385/143cb1d1-1fe1-4392-848a-db53601940b6)
![image](https://github.com/linuxdeepin/linglong-hub/assets/125240385/b718a0ac-3f5c-424b-ac6a-4f771c1fc7e2)
![image](https://github.com/linuxdeepin/linglong-hub/assets/125240385/f34fbca3-81f2-429d-b05d-8a881efec5e4)

