### PR TITLE
build: add app qcalcfilehash

### DIFF
--- a/io.github.qcalcfilehash/linglong.yaml
+++ b/io.github.qcalcfilehash/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.qcalcfilehash
+  name: qcalcfilehash
+  version: 1.1.1
+  kind: app
+  description: |
+    graphical utility for calculation and verification of hash sums
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/admsasha/qcalcfilehash.git
+  commit: 4335c7c95a5cde1e5fe7065c509d39e764f24015
+  patch: patches/fix_001.patch
+
+build:
+  kind: qmake
+
+

--- a/io.github.qcalcfilehash/patches/fix_001.patch
+++ b/io.github.qcalcfilehash/patches/fix_001.patch
@@ -1,0 +1,36 @@
+--- ../QCalcFileHash.pro	2023-12-18 11:20:14.817079000 +0800
++++ ../QCalcFileHash.pro	2023-12-18 11:26:07.650883000 +0800
+@@ -64,27 +64,27 @@
+ updateqm.CONFIG += no_link target_predeps
+ QMAKE_EXTRA_COMPILERS += updateqm
+ 
+-data_bin.path = /usr/bin/
++data_bin.path = $$PREFIX/bin/
+ data_bin.files = Bin/qcalcfilehash
+ INSTALLS += data_bin
+ 
+-data_app.path = /usr/share/applications/
++data_app.path = $$PREFIX/share/applications/
+ data_app.files = pkg/qcalcfilehash.desktop
+ INSTALLS += data_app
+ 
+-data_langs.path = /usr/share/qcalcfilehash/langs/
++data_langs.path = $$PREFIX/share/qcalcfilehash/langs/
+ data_langs.files = langs/*.qm langs/langs.json
+ INSTALLS += data_langs
+ 
+-data_icons16.path = /usr/share/icons/hicolor/16x16/apps/
++data_icons16.path = $$PREFIX/share/icons/hicolor/16x16/apps/
+ data_icons16.files = pkg/icons/16x16/qcalcfilehash.png
+ INSTALLS += data_icons16
+ 
+-data_icons32.path = /usr/share/icons/hicolor/32x32/apps/
++data_icons32.path = $$PREFIX/share/icons/hicolor/32x32/apps/
+ data_icons32.files = pkg/icons/32x32/qcalcfilehash.png
+ INSTALLS += data_icons32
+ 
+-data_icons48.path = /usr/share/icons/hicolor/48x48/apps/
++data_icons48.path = $$PREFIX/share/icons/hicolor/48x48/apps/
+ data_icons48.files = pkg/icons/48x48/qcalcfilehash.png
+ INSTALLS += data_icons48
+ 


### PR DESCRIPTION
新增应用qcalcfilehash,计算验证hash的图形应用程序
![295a8a21-bd21-44a6-afec-8f2c71dcaaea](https://github.com/linuxdeepin/linglong-hub/assets/117267185/bb113460-4f21-4498-bf81-45b931c71c19)
