### PR TITLE
build: add QMarkdownEditor

### DIFF
--- a/io.github.QMarkdownEditor/linglong.yaml
+++ b/io.github.QMarkdownEditor/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.QMarkdownEditor
+  name: QMarkdownEditor
+  version: 0.0.1
+  kind: app
+  description: |
+   Markdown editor written with Qt5
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/HamedMasafi/QMarkdownEditor.git"
+  commit: 8a4832a9326dcce763fea9276aa0573aae086570
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  

--- a/io.github.QMarkdownEditor/patches/0001-install.patch
+++ b/io.github.QMarkdownEditor/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 618af006620723089c59a7cbbe347be815d765a4 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 12 Dec 2023 18:56:17 +0800
+Subject: [PATCH] install
+
+---
+ MarkdownEdit.desktop | 8 ++++++++
+ MarkdownEdit.pro     | 9 ++++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 MarkdownEdit.desktop
+
+diff --git a/MarkdownEdit.desktop b/MarkdownEdit.desktop
+new file mode 100644
+index 0000000..c91a257
+--- /dev/null
++++ b/MarkdownEdit.desktop
+@@ -0,0 +1,8 @@
++[Desktop Entry]
++Categories=Game;Qt;
++Exec=MarkdownEdit
++Name=MarkdownEdit
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+\ No newline at end of file
+diff --git a/MarkdownEdit.pro b/MarkdownEdit.pro
+index 6469c2c..0a0dbbb 100644
+--- a/MarkdownEdit.pro
++++ b/MarkdownEdit.pro
+@@ -29,5 +29,12 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =MarkdownEdit.desktop
++desktop.path = $$DATADIR/applications/
++INSTALLS += target desktop
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Finish build for ll-build

Log: 完成的编译
![QMarkdownEditor](https://github.com/linuxdeepin/linglong-hub/assets/94835181/5246ee67-626c-4637-a75e-17d46c484094)
