### PR TITLE
build: add app ipqalc

### DIFF
--- a/com.debian.ipqalc/linglong.yaml
+++ b/com.debian.ipqalc/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: com.debian.ipqalc
+  name: ipqalc
+  version: 1.5.3
+  kind: app
+  description: |
+    Graphical utility for IPv4 subnet calculation.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://salsa.debian.org/debian/ipqalc.git
+  commit: 29e70faf468d126a81ec46744b42413e9f97b3bd
+  patch: patches/fix_001.patch  
+
+build:
+  kind: qmake

--- a/com.debian.ipqalc/patches/fix_001.patch
+++ b/com.debian.ipqalc/patches/fix_001.patch
@@ -1,0 +1,30 @@
+--- ../ipQalc.pro	2023-12-19 16:54:06.136658000 +0800
++++ ../ipQalc.pro	2023-12-19 16:53:51.548388000 +0800
+@@ -63,19 +63,23 @@
+ updateqm.CONFIG += no_link target_predeps
+ QMAKE_EXTRA_COMPILERS += updateqm
+ 
+-data_bin.path = /usr/bin/
++data_bin.path = $$PREFIX/bin/
+ data_bin.files = Bin/ipqalc
+ INSTALLS += data_bin
+ 
+-data_app.path = /usr/share/applications/
++data_app.path = $$PREFIX/share/applications/
+ data_app.files = pkg/ipqalc.desktop
+ INSTALLS += data_app
+ 
+-data_pixmaps.path = /usr/share/pixmaps/
++data_pixmaps.path = $$PREFIX/share/pixmaps/
+ data_pixmaps.files = pkg/ipqalc.png
+ INSTALLS += data_pixmaps
+ 
+-data_langs.path = /usr/share/ipqalc/langs/
++data_icons.path = $$PREFIX/share/icons/
++data_icons.files = pkg/ipqalc.png
++INSTALLS += data_icons
++
++data_langs.path = $$PREFIX/share/ipqalc/langs/
+ data_langs.files = langs/*.qm
+ INSTALLS += data_langs
+ 


### PR DESCRIPTION
新增应用ipqalc,用于 IP 地址计算的小型实用程序，包括广播和网络地址以及 Cisco 通配符掩码
![d7baefae-c0aa-4f5f-970d-784763de5a64](https://github.com/linuxdeepin/linglong-hub/assets/117267185/87c68c72-9dfd-4524-ba4e-bb774fa2578e)
