### PR TITLE
build: add ems-qart

### DIFF
--- a/io.github.ems-qart/linglong.yaml
+++ b/io.github.ems-qart/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.ems-qart
+  name: ems-qart
+  version: 0.9.4
+  kind: app
+  description: |
+    A Qt application to flash EMS 64M cartridges
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/rbino/ems-qart.git
+  commit: 2b88a04302865caefd7531c5972e053eaf01283e
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.ems-qart/patches/0001-install.patch
+++ b/io.github.ems-qart/patches/0001-install.patch
@@ -1,0 +1,43 @@
+From 57c2f7794d349032ffc4456381792a99e608264b Mon Sep 17 00:00:00 2001
+From: xwqlikepsl <2242484264@qq.com>
+Date: Wed, 20 Dec 2023 09:12:03 +0800
+Subject: [install.patch_] install
+
+---
+ ems-qart.desktop | 6 ++++++
+ ems-qart.pro     | 7 +++++++
+ 2 files changed, 13 insertions(+)
+ create mode 100644 ems-qart.desktop
+
+diff --git a/ems-qart.desktop b/ems-qart.desktop
+new file mode 100644
+index 0000000..627c73d
+--- /dev/null
++++ b/ems-qart.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Version=1.0
++Type=Application
++Name=ems-qart
++Exec=ems-qart
++Terminal=false
+\ No newline at end of file
+diff --git a/ems-qart.pro b/ems-qart.pro
+index 991c3cb..919cb53 100644
+--- a/ems-qart.pro
++++ b/ems-qart.pro
+@@ -28,3 +28,10 @@ unix:udevrules.files = 50_ems_gb_flash.rules
+ 
+ unix:target.path = $$PREFIX/bin/
+ unix:INSTALLS += target udevrules
++
++unix: {
++
++unix_desktop.path = $${PREFIX}/share/applications
++unix_desktop.files = ems-qart.desktop
++INSTALLS += unix_desktop
++}
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
Finish build ems-qart for ll-build

![image](https://github.com/linuxdeepin/linglong-hub/assets/89069734/6d707be9-c3fb-4564-a47c-1fd0de133f09)


Log: 完成App:ems-qart的编译