### PR TITLE
build: add app BoxBuddy

### DIFF
--- a/io.github.BoxBuddy/linglong.yaml
+++ b/io.github.BoxBuddy/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.BoxBuddy
+  name: BoxBuddy
+  version: 0.0.1
+  kind: app
+  description: |
+    An Unofficial GUI for managing multiple distros via Distrobox.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/Dvlv/BoxBuddy.git
+  commit: 24367bbed7140c637bb40d4b916bc9ec9f62085a
+  patch: patches/fix_001.patch 
+
+build:
+  kind: cmake

--- a/io.github.BoxBuddy/patches/fix_001.patch
+++ b/io.github.BoxBuddy/patches/fix_001.patch
@@ -1,0 +1,19 @@
+--- ../CMakeLists.txt	2023-12-20 14:21:23.297543000 +0800
++++ ../CMakeLists.txt	2023-12-20 14:20:03.296479000 +0800
+@@ -66,6 +66,16 @@
+ install(TARGETS boxbuddy
+     BUNDLE DESTINATION .
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=boxbuddy
++Exec=boxbuddy
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/boxbuddy.desktop "${DESKTOP_FILE_CONTENT}")
++install(PROGRAMS ${CMAKE_BINARY_DIR}/boxbuddy.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+ 
+ if(QT_VERSION_MAJOR EQUAL 6)
+     qt_finalize_executable(boxbuddy)


### PR DESCRIPTION
新增应用BoxBuddy,一个非官方的 GUI，用于通过 Distrobox 管理多个发行版
![cfae5e39-7e15-4137-adb3-1da55129a401](https://github.com/linuxdeepin/linglong-hub/assets/117267185/0805f883-e363-408c-a7eb-ce02b380dc6a)
