### PR TITLE
build: add seq66

### DIFF
--- a/io.github.seq66/linglong.yaml
+++ b/io.github.seq66/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.seq66
+  name: seq66
+  version: 0.99.10.1
+  kind: app
+  description: |
+    Seq66 MIDI sequencer/live-looper with a hardware-sampler grid interface; pattern banks, triggers, and playlists for song management; scale and chord aware piano-roll; song layout for creative composition; and control/status via MIDI automation for live performance. Mute-groups enable/disable multiple patterns at once. Supports the Non/New Session Manager; can also run headless. Works in a space as small as 725x500 pixels (less if window decoration removed). It does not support audio samples, just MIDI. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/ahlstromcj/seq66.git"
+  commit: 78536429770497c902d71853f3df0698adb1c0dd
+  patch:
+    - patches/fix-desktop.patch
+
+build:
+  kind: qmake
+  manual :
+    configure: |
+      cd Seq66qt5
+      qmake -makefile ${conf_args} ${extra_args}
+    manual :
+    configure: |
+      qmake -makefile ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.seq66/patches/fix-desktop.patch
+++ b/io.github.seq66/patches/fix-desktop.patch
@@ -1,0 +1,39 @@
+diff --git a/Seq66qt5/Seq66qt5.pro b/Seq66qt5/Seq66qt5.pro
+index ced96336..b13b4f21 100644
+--- a/Seq66qt5/Seq66qt5.pro
++++ b/Seq66qt5/Seq66qt5.pro
+@@ -159,6 +159,18 @@ windows:RC_ICONS += ../resources/icons/route66.ico \
+  ../resources/icons/route66-64x64.ico \
+  ../resources/icons/route66-256x256.ico
+ 
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += ../distros/debian/seq66.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++
++icons.path = $${PREFIX}/share/icons
++icons.files = ../resources/icons/route66.xpm
++INSTALLS += icons
++
+ #******************************************************************************
+ # Seq66qt5.pro (Seq66qt5)
+ #------------------------------------------------------------------------------
+diff --git a/distros/debian/seq66.desktop b/distros/debian/seq66.desktop
+index 862ffe2d..514649a6 100644
+--- a/distros/debian/seq66.desktop
++++ b/distros/debian/seq66.desktop
+@@ -4,9 +4,9 @@ Version=1.0
+ GenericName=Live Grid Sequencer
+ Comment=MIDI Loop Sequencer derived from seq24
+ Comment[fr]=Séquenceur de boucle MIDI dérivé de seq24
+-Icon=/usr/share/pixmaps/seq66.xpm
++Icon=route66.xpm
+ Type=Application
+ Categories=Qt;AudioVideo;Audio;Midi;Music;Sequencer;X-Alsa;X-Jack;X-MIDI;
+-Exec=qseq66
++Exec=qpseq66
+ Terminal=false
+ X-NSM-Capable=true


### PR DESCRIPTION

![seq66](https://github.com/linuxdeepin/linglong-hub/assets/59505865/95707985-d2e9-4870-a5ec-7e24ccdb54b1)

Log: 完成App：seq66的编译。
更新了版本号。
优化使用了自带desktop文件。