### PR TITLE
build: add sequencer64

### DIFF
--- a/io.github.sequencer64/linglong.yaml
+++ b/io.github.sequencer64/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.sequencer64
+  name: sequencer64
+  version: 0.97.0.5
+  kind: app
+  description: |
+    Sequencer64 is a live MIDI looper with a song-creation layout window. Sequencer64 is a reboot of seq24, extending it greatly over the last six years. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/ahlstromcj/sequencer64.git"
+  commit: 064c83cd13f35089f186d0a0b592254d504e97a3
+  patch:
+    - patches/fix_desktop.patch
+
+build:
+  kind: qmake
+

--- a/io.github.sequencer64/patches/fix_desktop.patch
+++ b/io.github.sequencer64/patches/fix_desktop.patch
@@ -1,0 +1,40 @@
+diff --git a/Seq64qt5/Seq64qt5.pro b/Seq64qt5/Seq64qt5.pro
+index 5101f9d0..2040f1f7 100644
+--- a/Seq64qt5/Seq64qt5.pro
++++ b/Seq64qt5/Seq64qt5.pro
+@@ -97,6 +97,18 @@ unix:!macx: LIBS += \
+ 
+ windows: LIBS += -lwinmm
+ 
++
++desktop.path = $$PREFIX/share/applications
++desktop.files += ../debian/sequencer64.desktop
++INSTALLS += desktop
++
++target.path = $$PREFIX/bin
++INSTALLS += target
++
++icons.path = $${PREFIX}/share/icons
++icons.files = ../resources/icons/sequencer64.png
++INSTALLS += icons
++
+ #******************************************************************************
+ # Seq64qt5.pro (Seq64qt5)
+ #------------------------------------------------------------------------------
+diff --git a/debian/sequencer64.desktop b/debian/sequencer64.desktop
+index 991692bd..d4ea1b76 100644
+--- a/debian/sequencer64.desktop
++++ b/debian/sequencer64.desktop
+@@ -3,10 +3,10 @@ Name=Sequencer64
+ GenericName=Sequencer64
+ Comment=MIDI Loop Sequencer derived from seq24
+ Comment[fr]=Séquenceur de boucle MIDI dérivé de seq24
+-Icon=/usr/share/pixmaps/sequencer64.xpm
++Icon=sequencer64.png
+ 
+ Type=Application
+ Categories=AudioVideo;Audio;
+ 
+-Exec=seq64
++Exec=qpseq64
+ Terminal=false


### PR DESCRIPTION

![sequencer64](https://github.com/linuxdeepin/linglong-hub/assets/59505865/ab8c3688-0c6d-45b8-8a0f-bfc5a4f4225a)

Log: 完成App：sequencer64的编译
修复使用自带desktop文件
版本号已升级