### PR TITLE
build: add coolreader

### DIFF
--- a/io.github.coolreader/linglong.yaml
+++ b/io.github.coolreader/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.coolreader
+  name: coolreader
+  version: 3.2.58
+  kind: app
+  description: |
+    Official site of CoolReader project. Sourceforge repository is obsolete.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/buggins/coolreader.git
+  commit: 105a1ef1c456dd49fafae36f5e7cb7eb33ba957a
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Official site of CoolReader project. Sourceforge repository is obsolete.

Log: add software name--coolreader
![coolreader](https://github.com/linuxdeepin/linglong-hub/assets/147463620/78ed1af5-29e1-4ff2-9631-7dcd01d1f94c)
