### PR TITLE
build: add qmidinet

### DIFF
--- a/io.github.qmidinet/linglong.yaml
+++ b/io.github.qmidinet/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.qmidinet
+  name: qmidinet
+  version: 0.9.11
+  kind: app
+  description: |
+    QmidiNet - A MIDI Network Gateway via UDP/IP Multicast
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/rncbc/qmidinet.git
+  commit: ab27e04dd9c7cbb53f9c1f6d987495fbbd29fa3e
+
+build:
+  kind: cmake


### PR DESCRIPTION
    QmidiNet - A MIDI Network Gateway via UDP/IP Multicast

Log: add software name--qmidinet
![qmidinet](https://github.com/linuxdeepin/linglong-hub/assets/147463620/744afbb6-0299-47bd-a259-2367a8d9685e)
