### PR TITLE
build: add ArrowDL

### DIFF
--- a/io.github.ArrowDL/linglong.yaml
+++ b/io.github.ArrowDL/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.ArrowDL
+  name: ArrowDL
+  version: 2.5.0
+  kind: app
+  description: |
+    ArrowDL (Arrow Downloader) is a download manager for Windows, MacOS and Linux
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/setvisible/ArrowDL.git
+  commit: 0c87b4720312edc45e2fd396dab7c57d19d159f4
+  patch:
+    - patches/0001-install.patch
+    - patches/0002-install.patch
+
+build:
+  kind: cmake

--- a/io.github.ArrowDL/patches/0001-install.patch
+++ b/io.github.ArrowDL/patches/0001-install.patch
@@ -1,0 +1,37 @@
+From d6200ab0412146a3a76bba67f18ed84ef6b8de2f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 5 Jan 2024 18:11:38 +0800
+Subject: [PATCH] install
+
+---
+ src/CMakeLists.txt | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 159529f..7477948 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -102,7 +102,7 @@ endif(USE_QT_WEBENGINE)
+ ##############################################################################
+ install(TARGETS ${DownZemAll_NAME}
+     RUNTIME
+-    DESTINATION ${CMAKE_INSTALL_PREFIX}
++    DESTINATION bin
+     )
+ 
+ install (
+@@ -131,7 +131,9 @@ endif()
+ 
+ install (
+     FILES ${Desktop_Shortcut}
+-    DESTINATION ${CMAKE_INSTALL_PREFIX}/desktop_shortcut
++    DESTINATION share/applications
+     COMPONENT release_docs
+     )
+ 
++install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/installer/unix/portable/DownZemAll_64x64.png
++        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps/")
+\ No newline at end of file
+-- 
+2.33.1
+

--- a/io.github.ArrowDL/patches/0002-install.patch
+++ b/io.github.ArrowDL/patches/0002-install.patch
@@ -1,0 +1,24 @@
+From f843879a645ca7dd0b77df32ad1e1b6c36e3da32 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 5 Jan 2024 17:58:46 +0800
+Subject: [PATCH] install
+
+---
+ installer/unix/portable/DownZemAll.desktop | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/installer/unix/portable/DownZemAll.desktop b/installer/unix/portable/DownZemAll.desktop
+index e33a9e6..b5a35bf 100644
+--- a/installer/unix/portable/DownZemAll.desktop
++++ b/installer/unix/portable/DownZemAll.desktop
+@@ -8,5 +8,5 @@ Comment[fr]=Le parfait téléchargeur de masse
+ Categories=Utility;
+ StartupNotify=false
+ Terminal=false
+-Exec=/ABSOLUTE/PATH/TO/APP/DIRECTORY/../DownZemAll %U
+-Icon=/ABSOLUTE/PATH/TO/APP/DIRECTORY/DownZemAll_64x64.png
++Exec=DownZemAll
++Icon=DownZemAll_64x64.png
+-- 
+2.33.1
+


### PR DESCRIPTION
    ArrowDL (Arrow Downloader) is a download manager for Windows, MacOS and Linux

Log: add software name--ArrowDL
![ArrowDL](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a22980d1-de7e-44c0-9237-5c9526d00a23)
