### PR TITLE
build: add frsky_sport_tool

### DIFF
--- a/io.github.frsky_sport_tool/linglong.yaml
+++ b/io.github.frsky_sport_tool/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.frsky_sport_tool
+  name: frsky_sport_tool
+  version: 0.2.0
+  kind: app
+  description: |
+    Open-Source, Multi-Platform Frsky Sport Tool Suite for firmware programming, device configuration, and data monitoring of Frsky RC Receivers and Telemetry devices.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dewhisna/frsky_sport_tool.git
+  commit: 231159b97bda6e6b9147b645d05ed306aa6c98a3
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.frsky_sport_tool/patches/0001-install.patch
+++ b/io.github.frsky_sport_tool/patches/0001-install.patch
@@ -1,0 +1,29 @@
+From 5d7f99cdf70735877689eadb9e7b3c3393caeb39 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 6 Jan 2024 13:42:27 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 36f9474..dce72ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -124,3 +124,11 @@ target_link_libraries(frsky_sport_tool PRIVATE
+ 
+ add_subdirectory(frsky_firmware_flash)
+ add_subdirectory(frsky_device_emu)
++
++install(TARGETS ${PROJECT_NAME}
++             DESTINATION bin)
++install(FILES frsky_sport_tool4.png
++        DESTINATION share/icons)
++
++install(FILES frsky_sport_tool.desktop
++            DESTINATION share/applications)
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Open-Source, Multi-Platform Frsky Sport Tool Suite for firmware programming, device configuration, and data monitoring of Frsky RC Receivers and Telemetry devices.

Log: add software name--frsky_sport_tool
![frsky_sport_tool](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e8ca02bd-8fd4-4cc7-8d70-44b02f68fcad)
