### PR TITLE
build: add basic_numerical_methods

### DIFF
--- a/io.github.basic_numerical_methods/linglong.yaml
+++ b/io.github.basic_numerical_methods/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.basic_numerical_methods
+  name: basic_numerical_methods
+  version: 3.0.9
+  kind: app
+  description: |
+    A Qt application for basic numerical methods.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/hafmed/basic_numerical_methods.git
+  commit: 03077a360081a13651b9ea844d90d17323b58d68
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.basic_numerical_methods/patches/0001-install.patch
+++ b/io.github.basic_numerical_methods/patches/0001-install.patch
@@ -1,0 +1,29 @@
+From 613181c524034c5e4988d736954009e779a92f9b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 8 Jan 2024 19:06:13 +0800
+Subject: [PATCH] install
+
+---
+ src/basic_numerical_methods.pro | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/basic_numerical_methods.pro b/src/basic_numerical_methods.pro
+index 54ca030..9b81943 100644
+--- a/src/basic_numerical_methods.pro
++++ b/src/basic_numerical_methods.pro
+@@ -44,3 +44,12 @@ RESOURCES += \
+ 
+ win32:RC_ICONS += basic_numerical_methods.ico
+ 
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =basic_numerical_methods.desktop
++desktop.path = $$DATADIR/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = basic_numerical_methods.png
++INSTALLS += target desktop icons
++
+-- 
+2.33.1
+


### PR DESCRIPTION
    A Qt application for basic numerical methods.

Log: add software name--basic_numerical_methods
![basic_numerical_methods](https://github.com/linuxdeepin/linglong-hub/assets/147463620/43c11c7e-44b3-48b0-956d-6a4b377363b6)
