### PR TITLE
build: add brickstore

### DIFF
--- a/io.github.brickstore/linglong.yaml
+++ b/io.github.brickstore/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.brickstore
+  name: brickstore
+  version: 2021.1.0
+  kind: app
+  description: |
+    An offline BrickLink inventory management tool.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtscript/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/rgriebl/brickstore.git
+  commit: c9da44132419b0f45929f72b63d9abd6f40f22e0
+
+build:
+  kind: qmake


### PR DESCRIPTION
    An offline BrickLink inventory management tool.

Log: add software name--brickstore
![brickstore](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ba6ca302-d224-44a9-8bb6-c93fce1324df)
