### PR TITLE
build: add qView-minimal

### DIFF
--- a/io.github.qView-minimal/linglong.yaml
+++ b/io.github.qView-minimal/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.qView-minimal
+  name: qView-minimal
+  version: 3.0.0
+  kind: app
+  description: |
+    Practical and minimal image viewer
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Qt-Widgets/qView-minimal-image-viewer.git
+  commit: a744bf572a0a84e19a4822bc8922c7230e5a67ab
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.qView-minimal/patches/0001-install.patch
+++ b/io.github.qView-minimal/patches/0001-install.patch
@@ -1,0 +1,51 @@
+From 592e133d48691cf091a95580aebdb14375ab1269 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 6 Jan 2024 19:15:13 +0800
+Subject: [PATCH] install
+
+---
+ qView.pro | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/qView.pro b/qView.pro
+index 2dcb5fa..f9f0b21 100644
+--- a/qView.pro
++++ b/qView.pro
+@@ -35,23 +35,25 @@ QMAKE_INFO_PLIST = "dist/mac/Info.plist"
+ ICON = "dist/mac/qView.icns"
+ 
+ # Linux specific stuff
+-binary.path = /usr/bin
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++binary.path = $$PREFIX/bin
+ binary.files = bin/qview
+-desktop.path = /usr/share/applications
++desktop.path = $$DATADIR/applications/
+ desktop.files = dist/linux/qView.desktop
+-icon16.path = /usr/share/icons/hicolor/16x16/apps/
++icon16.path = $$PREFIX/share/icons/hicolor/16x16/apps/
+ icon16.files = dist/linux/hicolor/16x16/apps/qview.png
+-icon32.path = /usr/share/icons/hicolor/32x32/apps/
++icon32.path = $$PREFIX//share/icons/hicolor/32x32/apps/
+ icon32.files = dist/linux/hicolor/32x32/apps/qview.png
+-icon64.path = /usr/share/icons/hicolor/64x64/apps/
++icon64.path = $$PREFIX/share/icons/hicolor/64x64/apps/
+ icon64.files = dist/linux/hicolor/64x64/apps/qview.png
+-icon128.path = /usr/share/icons/hicolor/128x128/apps/
++icon128.path = $$PREFIX/share/icons/hicolor/128x128/apps/
+ icon128.files = dist/linux/hicolor/128x128/apps/qview.png
+-icon256.path = /usr/share/icons/hicolor/256x256/apps/
++icon256.path = $$PREFIX/share/icons/hicolor/256x256/apps/
+ icon256.files = dist/linux/hicolor/256x256/apps/qview.png
+-iconsvg.path = /usr/share/icons/hicolor/scalable/apps/
++iconsvg.path = $$PREFIX/share/icons/hicolor/scalable/apps/
+ iconsvg.files = dist/linux/hicolor/scalable/apps/qview.svg
+-license.path = /usr/share/licenses/qview/
++license.path = $$PREFIX/share/licenses/qview/
+ license.files = LICENSE
+ 
+ unix:!macx:INSTALLS += binary desktop icon16 icon32 icon64 icon128 icon256 iconsvg license
+-- 
+2.33.1
+


### PR DESCRIPTION
    Practical and minimal image viewer

Log: add software name--qView-minimal
![qView-minimal-image-viewer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/8f14634c-d05d-4e2c-874b-d6dbb1630379)
