### PR TITLE
build: add antimicrox

### DIFF
--- a/io.github.antimicrox/linglong.yaml
+++ b/io.github.antimicrox/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.antimicrox
+  name: antimicrox
+  version: 3.4.4
+  kind: app
+  description: |
+    Graphical program used to map keyboard buttons and mouse controls to a gamepad. Useful for playing games with no gamepad support.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/AntiMicroX/antimicrox.git
+  commit: d00ab91154ff79a72b1ee87ce7dce72329289c3f
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.antimicrox/patches/0001-install.patch
+++ b/io.github.antimicrox/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From 8f340f507c52385b0f38cf74aa5069d612aac64c Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 8 Jan 2024 20:08:05 +0800
+Subject: [PATCH] install
+  
+---
+ other/appdata/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/other/appdata/CMakeLists.txt b/other/appdata/CMakeLists.txt
+index 840fe84c..78d3c545 100644
+--- a/other/appdata/CMakeLists.txt
++++ b/other/appdata/CMakeLists.txt
+@@ -10,7 +10,7 @@ if(APPDATA)
+ 
+             COMMAND itstool -i "${PROJECT_SOURCE_DIR}/other/appdata/appdata.its" -j "${PROJECT_SOURCE_DIR}/other/appdata/io.github.antimicrox.antimicrox.appdata.xml.in" -o "io.github.antimicrox.antimicrox.appdata.xml" "${CMAKE_CURRENT_BINARY_DIR}/PO_files/*.mo"
+             )
+-
++configure_file(io.github.antimicrox.antimicrox.appdata.xml.in ${CMAKE_CURRENT_BINARY_DIR}/io.github.antimicrox.antimicrox.appdata.xml COPYONLY)
+     # Only install an appdata file ifthe user requested to have one built.
+     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/io.github.antimicrox.antimicrox.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
+ endif(APPDATA)
+-- 
+2.33.1
+


### PR DESCRIPTION
    Graphical program used to map keyboard buttons and mouse controls to a gamepad. Useful for playing games with no gamepad support.

Log: add software name--antimicrox
![antimicrox](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9a655bb9-40b4-4885-a4c6-f70cf9d8891a)
