### PR TITLE
build: add obs-studio

### DIFF
--- a/io.github.obs-studio/linglong.yaml
+++ b/io.github.obs-studio/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.obs-studio
+  name: obs-studio
+  version: 26.0.1
+  kind: app
+  description: |
+    OBS Studio - Free and open source software for live streaming and screen recording
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/obsproject/obs-studio.git
+  commit: 50cbafd711c3899d886ff2401787e15f1e38fbee
+
+build:
+  kind: cmake


### PR DESCRIPTION
    OBS Studio - Free and open source software for live streaming and screen recording

Log: add software name--obs-studio
![obs-studio](https://github.com/linuxdeepin/linglong-hub/assets/147463620/bbab3b2a-c84a-428a-b6cf-d833ca84732d)
