### PR TITLE
build: add ProcDepMonitor

### DIFF
--- a/io.github.ProcDepMonitor/linglong.yaml
+++ b/io.github.ProcDepMonitor/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.ProcDepMonitor
+  name: ProcDepMonitor
+  version: 1.2.0.2
+  kind: app
+  description: |
+    Cross-platform process dependency monitor with GUI based on Qt
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/3dproger/ProcDepMonitor.git
+  commit: 42f6bfd2ee57afe705b64e105fc0895de6d76184
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake ProcDepMonitor.pro  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.ProcDepMonitor/patches/0001-install.patch
+++ b/io.github.ProcDepMonitor/patches/0001-install.patch
@@ -1,0 +1,34 @@
+From 13554ac481978463c1be10248eee94e5fb96b2ed Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 9 Jan 2024 15:09:06 +0800
+Subject: [PATCH] install
+
+---
+ src/ProcDepMonitor.pro | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/ProcDepMonitor.pro b/src/ProcDepMonitor.pro
+index f0acbc8..b0dce31 100644
+--- a/src/ProcDepMonitor.pro
++++ b/src/ProcDepMonitor.pro
+@@ -143,5 +143,15 @@ CONFIG(debug, debug|release) {
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =../deploy/unix/linuxdeployqt/app.desktop
++desktop.path = $$DATADIR/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../deploy/unix/linuxdeployqt/icons/hicolor/64x64/apps/procdepmonitor.png
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Cross-platform process dependency monitor with GUI based on Qt

Log: add software name--ProcDepMonitor
![ProcDepMonitor](https://github.com/linuxdeepin/linglong-hub/assets/147463620/eab4f13b-001d-49a8-b479-4a1fe0c299c9)
