### PR TITLE
build: add pdfquirk

### DIFF
--- a/io.github.pdfquirk/linglong.yaml
+++ b/io.github.pdfquirk/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.pdfquirk
+  name: pdfquirk
+  version: 0.95.1
+  kind: app
+  description: |
+    Creating PDFs from images or scanner made easy.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dragotin/pdfquirk.git
+  commit: 79f3bb003a0e269399b1eec4632411090ad79e84
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Creating PDFs from images or scanner made easy.

Log: add software name--pdfquirk
![pdfquirk](https://github.com/linuxdeepin/linglong-hub/assets/147463620/fc24e633-465d-4024-b66f-fcba8410bd61)
