### PR TITLE
build: add kleiner-brauhelfer-2

### DIFF
--- a/io.github.kleiner-brauhelfer-2/linglong.yaml
+++ b/io.github.kleiner-brauhelfer-2/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.kleiner-brauhelfer-2
+  name: kleiner-brauhelfer-2
+  version: 2.2.0
+  kind: app
+  description: |
+    Der kleine-brauhelfer ist ein Hilfsprogramm f¨¹r Hobbybrauer zum Erstellen und Verwalten von Biersuden.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+    type: runtime
+  - id: qtcharts/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2.git
+  commit: 0706ab69cfa72de352f4d0673529820128cf5a4f
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  

--- a/io.github.kleiner-brauhelfer-2/patches/0001-install.patch
+++ b/io.github.kleiner-brauhelfer-2/patches/0001-install.patch
@@ -1,0 +1,30 @@
+From 2229638d056255fd082f7c7b6bb14aea73b8066f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 9 Jan 2024 16:05:15 +0800
+Subject: [PATCH] install
+
+---
+ kleiner-brauhelfer/kleiner-brauhelfer.pro | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/kleiner-brauhelfer/kleiner-brauhelfer.pro b/kleiner-brauhelfer/kleiner-brauhelfer.pro
+index 3d29493..567a202 100644
+--- a/kleiner-brauhelfer/kleiner-brauhelfer.pro
++++ b/kleiner-brauhelfer/kleiner-brauhelfer.pro
+@@ -236,3 +236,13 @@ RESOURCES += \
+ TRANSLATIONS += \
+     translations/kbh_en.ts \
+     translations/kbh_sv.ts
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =../deployment/linux/64bit/AppImage/kleiner-brauhelfer-2.desktop
++desktop.path = $$DATADIR/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../deployment/kleiner-brauhelfer-2.svg
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    Der kleine-brauhelfer ist ein Hilfsprogramm f¨¹r Hobbybrauer zum Erstellen und Verwalten von Biersuden.

Log: add software name--kleiner-brauhelfer-2
![kleiner-brauhelfer-2](https://github.com/linuxdeepin/linglong-hub/assets/147463620/d79d673d-c7ff-423f-b49c-676db4c87859)
