### PR TITLE
build: add subtivals

### DIFF
--- a/io.github.subtivals/linglong.yaml
+++ b/io.github.subtivals/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.subtivals
+  name: subtivals
+  version: 1.10.0
+  kind: app
+  description: |
+    Subtivals is a tool to project subtitles under a movie in festivals, specialy targeted at the hard of hearing community.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Subtivals/subtivals.git
+  commit: ec820876325bd51e860bf2e329d171321853dad1
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install


### PR DESCRIPTION
    Subtivals is a tool to project subtitles under a movie in festivals, specialy targeted at the hard of hearing community.

Log: add software name--subtivals
![subtivals](https://github.com/linuxdeepin/linglong-hub/assets/147463620/aa819e64-5650-411c-9567-b54d2ebf5093)
