### PR TITLE
build: add Forserino

### DIFF
--- a/io.github.Forserino/linglong.yaml
+++ b/io.github.Forserino/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.Forserino
+  name: Forserino
+  version: 2.3.4
+  kind: app
+  description: |
+    Chat client for twitch.tv. See releases for download. Only nightlies are supported.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/felyp7/Forserino.git
+  commit: dbb00895d8c87c1ed93eb99ab30bf1d59c070c19
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Chat client for twitch.tv. See releases for download. Only nightlies are supported.

Log: add software name--Forserino
![Forserino](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e403544d-7d2c-42b2-afa0-c7d7bfad4137)
