### PR TITLE
build: add ser-player

### DIFF
--- a/io.github.ser-player/linglong.yaml
+++ b/io.github.ser-player/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.ser-player
+  name: ser-player
+  version: 1.7.3
+  kind: app
+  description: |
+    A simple video player for playing SER files used for solar, lunar and planetary astronomy-imaging.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/cgarry/ser-player.git
+  commit: 459576c0677fa5b4588518f5a06a9d291a9bb7a0
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.ser-player/patches/0001-install.patch
+++ b/io.github.ser-player/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From af6631d5e763a5b1667f21e7bd442119584ec92e Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 10 Jan 2024 11:55:50 +0800
+Subject: [PATCH] install
+
+---
+ src/frame_slider.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/frame_slider.cpp b/src/frame_slider.cpp
+index 5d834f1..d45dbdd 100644
+--- a/src/frame_slider.cpp
++++ b/src/frame_slider.cpp
+@@ -23,7 +23,7 @@
+ #include <QPainter>
+ #include <QSlider>
+ #include <QStyleOptionSlider>
+-
++#include <QPainterPath>
+ #include <cassert>
+ 
+ #include "persistent_data.h"
+-- 
+2.33.1
+


### PR DESCRIPTION
    A simple video player for playing SER files used for solar, lunar and planetary astronomy-imaging.

Log: add software name--ser-player
![ser-player](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a17f2ebf-9d3c-4810-a511-e6b194482cf5)
