### PR TITLE
build: add Intan-RHX

### DIFF
--- a/io.github.Intan-RHX/linglong.yaml
+++ b/io.github.Intan-RHX/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.Intan-RHX
+  name: Intan-RHX
+  version: 3.3.3
+  kind: app
+  description: |
+    Intan RHX is free, powerful data acquisition software that displays and records electrophysiological signals from any Intan RHD or RHS system using an RHD USB interface board
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Intan-Technologies/Intan-RHX.git
+  commit: 0829e0b47cf4a9a2a961e5e597a678c7d4d1b096
+  patch: 
+    - patches/0001-install.patch
+    - patches/0002-install.patch
+
+build:
+  kind: qmake

--- a/io.github.Intan-RHX/patches/0001-install.patch
+++ b/io.github.Intan-RHX/patches/0001-install.patch
@@ -1,0 +1,26 @@
+From 9472094e0cac0ba1b5493e6f2c5136e7f3a28dda Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 7 Dec 2023 10:03:21 +0800
+Subject: [PATCH] install
+
+---
+ Engine/Processing/DataFileReaders/fileperchannelmanager.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp b/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
+index e3e25b7..224a627 100644
+--- a/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
++++ b/Engine/Processing/DataFileReaders/fileperchannelmanager.cpp
+@@ -27,7 +27,8 @@
+ //  See <http://www.intantech.com> for documentation and product information.
+ //
+ //------------------------------------------------------------------------------
+-
++#include <thread>
++#include <chrono>
+ #include <QFileInfo>
+ #include <iostream>
+ #include "rhxglobals.h"
+-- 
+2.33.1
+

--- a/io.github.Intan-RHX/patches/0002-install.patch
+++ b/io.github.Intan-RHX/patches/0002-install.patch
@@ -1,0 +1,45 @@
+From d784ba29794b6278bb7c2d826b5b383bddc36105 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 11 Jan 2024 14:58:41 +0800
+Subject: [PATCH] install
+
+---
+ IntanRHX.pro                            | 13 +++++++++++++
+ contrib/com.intantech.intan_rhx.desktop |  2 +-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/IntanRHX.pro b/IntanRHX.pro
+index 458ae34..4bb5bc7 100644
+--- a/IntanRHX.pro
++++ b/IntanRHX.pro
+@@ -289,3 +289,16 @@ LIBS += -L$$PWD/libraries/Linux/ -lokFrontPanel # Opal Kelly Front Panel library
+ QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN\'' # Flag that at runtime, look for shared libraries (like
+                                            # libokFrontPanel.so) at the same directory as the binary
+ }
++
++
++
++BINDIR = $$PREFIX/bin
++DATADIR = $$PREFIX/share
++target.path = $$BINDIR
++desktop.files =contrib/com.intantech.intan_rhx.desktop
++desktop.path = $$DATADIR/applications/
++icons.files = images/intan-rhx.svg
++icons.path = $$PREFIX/share/icons
++lib.files = libraries/Linux/libokFrontPanel.so
++lib.path = $$BINDIR
++INSTALLS += target desktop icons lib
+diff --git a/contrib/com.intantech.intan_rhx.desktop b/contrib/com.intantech.intan_rhx.desktop
+index ef44aa3..c5e48c4 100644
+--- a/contrib/com.intantech.intan_rhx.desktop
++++ b/contrib/com.intantech.intan_rhx.desktop
+@@ -7,5 +7,5 @@ Comment=A free, powerful data acquisition software for electrophysiological sign
+ Categories=Science;Biology;
+ 
+ Icon=intan-rhx
+-Exec=intan-rhx
++Exec=IntanRHX
+ Terminal=false
+-- 
+2.33.1
+


### PR DESCRIPTION
    Intan RHX is free, powerful data acquisition software that displays and records electrophysiological signals from any Intan RHD or RHS system using an RHD USB interface board

Log: add software name--Intan-RHX
![Intan-RHX](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ce29289a-ec98-4176-94fd-42b5c1758da7)
