### PR TITLE
build: add lib fio

### DIFF
--- a/fio/linglong.yaml
+++ b/fio/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: fio
+  name: fio
+  version: 3.36.0
+  kind: lib
+  description: |
+    Flexible I/O Tester.
+
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/axboe/fio.git
+  commit: 624e263f6acb1563471a83601ce19dfb77ac5694
+
+build:
+  kind: autotools
+  manual:
+    configure: |
+      ./configure --prefix=${PREFIX}


### PR DESCRIPTION
Flexible I/O Tester.

 `configure` 不支持 `libdir` 参数
![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/f70640f4-b8e2-4cee-9229-3c8aba713af2)


Logs: add lib fio