### PR TITLE
build: add app gtest-runner

### DIFF
--- a/io.github.gtest-runner/linglong.yaml
+++ b/io.github.gtest-runner/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.gtest-runner
+  name: gtest-runner
+  version: 1.4.0
+  kind: app
+  description: |
+    A cross-platform, Qt5 based Graphical User Interface for Google Test unit tests.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/nholthaus/gtest-runner.git
+  commit: da39a2c7687d52026edb752f260930f1312b50f4
+  patch:
+    - patches/fix_build.patch
+
+build:
+  kind: cmake

--- a/io.github.gtest-runner/patches/fix_build.patch
+++ b/io.github.gtest-runner/patches/fix_build.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2eb2d38..67a3628 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,9 +70,9 @@ find_package(Qt5Test REQUIRED)
+ # Test for supported Qt version
+ find_program(QMAKE_EXECUTABLE NAMES qmake HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
+ execute_process(COMMAND ${QMAKE_EXECUTABLE} -query QT_VERSION OUTPUT_VARIABLE QT_VERSION)
+-if(QT_VERSION LESS QT_MINIMUM_VERSION)
+-	MESSAGE(FATAL_ERROR "Minimum supported Qt version: ${QT_MINIMUM_VERSION}. Installed version: ${QT_VERSION}")
+-endif()
++#if(QT_VERSION LESS QT_MINIMUM_VERSION)
++#	MESSAGE(FATAL_ERROR "Minimum supported Qt version: ${QT_MINIMUM_VERSION}. Installed version: ${QT_VERSION}")
++#endif()
+ 
+ # find thread library 
+ find_package(Threads REQUIRED)
+@@ -277,4 +277,4 @@ SET(CPACK_PACKAGE_INSTALL_DIRECTORY "${TARGET_NAME}")
+ set(CPACK_PACKAGE_DIRECTORY ${PROJECT_BINARY_DIR}/Release)
+ set(CPACK_PACKAGE_EXECUTABLES "${TARGET_NAME}" "gtest-runner")
+ 
+-INCLUDE(CPack)
+\ No newline at end of file
++INCLUDE(CPack)


### PR DESCRIPTION
A cross-platform, Qt5 based Graphical User Interface for Google Test unit tests.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/e674416b-6015-4a2d-b06c-cc00d6efc2f4)

Logs: add app name--gtest-runner