### PR TITLE
build: add FastQt

### DIFF
--- a/io.github.FastQt/linglong.yaml
+++ b/io.github.FastQt/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.FastQt
+  name: FastQt
+  version: 0.0.2
+  kind: app
+  description: |
+    FastQC port to Qt5: A quality control tool for high throughput sequence data.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: karchive/5.90.0
+    type: runtime
+  - id: qtcharts/5.15.7
+    type: runtime
+
+source:  
+  kind: git
+  url: https://github.com/labsquare/FastQt.git
+  commit: 761e422e0989271f3cc684acf589f9953ecc8e8e
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.FastQt/patches/0001-install.patch
+++ b/io.github.FastQt/patches/0001-install.patch
@@ -1,0 +1,41 @@
+From 9b0fb300c9037a0554c49a006fbe5cb2b18523fb Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 24 Jan 2024 18:22:17 +0800
+Subject: [PATCH] install
+
+---
+ FastQt.pro | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/FastQt.pro b/FastQt.pro
+index 44ffac6..4a229b6 100644
+--- a/FastQt.pro
++++ b/FastQt.pro
+@@ -15,8 +15,8 @@ QMAKE_CXXFLAGS += -std=c++11
+ 
+ # METHOD 2 : Otherwise link it as a common library
+ unix {
+-INCLUDEPATH += "/usr/include/KF5/KArchive"
+-LIBS +=  -L"/usr/lib"  -lKF5Archive
++INCLUDEPATH += $${PREFIX}/include/KF5/KArchive
++LIBS +=  -L$${PREFIX}/lib  -lKF5Archive
+ }
+ 
+ win32{
+@@ -33,10 +33,10 @@ TARGET = fastqt
+ TEMPLATE = app
+ 
+ # Installation
+-target.path  = /usr/local/bin
+-desktop.path = /usr/share/applications
++target.path  = $${PREFIX}/bin
++desktop.path = $${PREFIX}/share/applications
+ desktop.files += fastqt.desktop
+-icons.path = /usr/share/icons/hicolor/48x48/apps
++icons.path = $${PREFIX}/share/icons/hicolor/48x48/apps
+ icons.files += fastqt.png
+ 
+ INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    FastQC port to Qt5: A quality control tool for high throughput sequence data.

Log: add software name--FastQt
![FastQt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/93b94e57-65e1-44db-9db3-c12b6218bba8)
