### PR TITLE
build: add ChineseChess

### DIFF
--- a/io.github.ChineseChess/linglong.yaml
+++ b/io.github.ChineseChess/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.ChineseChess
+  name: ChineseChess
+  version: 6.1
+  kind: app
+  description: |
+    Cross-platform and online battle platform game based on Qt: Chinese Chess. Also known as:『Xiangqi』
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/XMuli/ChineseChess.git"
+  commit: e755af5c9b8024be10234e86d9f47b1bef697b6d
+  patch: patches/ab.patch
+build:
+  kind: qmake

--- a/io.github.ChineseChess/patches/ab.patch
+++ b/io.github.ChineseChess/patches/ab.patch
@@ -1,0 +1,21 @@
+diff -Naur b/ChineseChess.desktop a/ChineseChess.desktop
+--- b/ChineseChess.desktop	1970-01-01 08:00:00.000000000 +0800
++++ a/ChineseChess.desktop	2023-11-19 20:10:41.355207954 +0800
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Name= ChineseChess
++Exec= ChineseChess
++Type= Application
+diff -Naur b/ChineseChess.pro a/ChineseChess.pro
+--- b/ChineseChess.pro	2023-11-15 22:58:57.000000000 +0800
++++ a/ChineseChess.pro	2023-11-19 19:24:57.652696787 +0800
+@@ -49,4 +49,9 @@
+     chooseresource.qrc
+ 
+ RC_FILE = res.rc
++desktop.files += ChineseChess.desktop
++desktop.path = $${PREFIX}/share/applications
++target.path = $${PREFIX}/bin
++
++INSTALLS += target desktop
+ 


### PR DESCRIPTION
Cross-platform and online battle platform game based on Qt: Chinese Chess.
Log: add app name--ChineseChess
![图片](https://github.com/linuxdeepin/linglong-hub/assets/138977684/9bdaf026-b6cb-403c-b391-533e4c765ed3)
