### PR TITLE
build: add HJ-Editor

### DIFF
--- a/io.github.HJ-Editor/linglong.yaml
+++ b/io.github.HJ-Editor/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.HJ-Editor
+  name: HJ-Editor
+  version: 1.0
+  kind: app
+  description: |
+    Qt based simple C++ code editor with code highlighting, code completion and compiling/基于Qt的简单C++编辑器，带代码高亮、联想和编译运行功能 
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: "https://github.com/m-iDev-0792/HJ-Editor.git"
+  commit: bf4d55f
+  patch: patches/ab.patch
+
+build:
+  kind: qmake

--- a/io.github.HJ-Editor/patches/ab.patch
+++ b/io.github.HJ-Editor/patches/ab.patch
@@ -1,0 +1,21 @@
+diff -Naur b/HJ-Editor.desktop a/HJ-Editor.desktop
+--- b/HJ-Editor.desktop	1970-01-01 08:00:00.000000000 +0800
++++ a/HJ-Editor.desktop	2023-11-26 20:08:41.587733203 +0800
+@@ -0,0 +1,4 @@
++[Desktop Entry]
++Name=HJ-Editor
++Exec=HJ-Editor
++Type=Application
+diff -Naur b/HJ-Editor.pro a/HJ-Editor.pro
+--- b/HJ-Editor.pro	2023-11-26 20:06:18.491628330 +0800
++++ a/HJ-Editor.pro	2023-12-02 14:48:17.034818703 +0800
+@@ -45,3 +45,9 @@
+     image.qrc
+ 
+ ICON = icon.icns
++
++
++desktop.files += HJ-Editor.desktop
++desktop.path = $${PREFIX}/share/applications
++target.path = $${PREFIX}/bin
++INSTALLS += target desktop


### PR DESCRIPTION
Qt based simple C++ code editor with code highlighting, code completion and compiling 
Log: add app name--HJ-Editor
![图片](https://github.com/linuxdeepin/linglong-hub/assets/138977684/a9b60c61-dfc2-4e70-b09b-7bfd39ed8bf3)
