### PR TITLE
build: add quassel

### DIFF
--- a/io.github.quassel/linglong.yaml
+++ b/io.github.quassel/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.quassel
+  name: quassel
+  version: 0.14.0
+  kind: app
+  description: |
+    Quassel IRC: Chat comfortably. Everywhere.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/quassel/quassel.git
+  commit: 020c163421691fa37330826df92ac0a248721290
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Quassel IRC: Chat comfortably. Everywhere.

Log: add software name--quassel
![quassel](https://github.com/linuxdeepin/linglong-hub/assets/147463620/acd4b94e-1b54-4358-a42a-2296fa745fe0)
