### PR TITLE
build: add qgo

### DIFF
--- a/io.github.qgo/linglong.yaml
+++ b/io.github.qgo/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.qgo
+  name: qgo
+  version: 2.1.0
+  kind: app
+  description: |
+    qGo is a Go Client (IGS, WING, LGS, WBaduk/CyberORO, Tygem, Tom, and eWeiqi) based on Qt 5. 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/pzorin/qgo.git
+  commit: 2a4212d473372bb531fdc5c919a20dd96819f9b0
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.qgo/patches/0001-install.patch
+++ b/io.github.qgo/patches/0001-install.patch
@@ -1,0 +1,38 @@
+From dab74a11dac3333d513c80efa95f5a432d480f24 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 20 Feb 2024 15:47:53 +0800
+Subject: [PATCH] install
+
+---
+ src/src.pro | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/src.pro b/src/src.pro
+index 2a9d893..9c581cb 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -168,17 +168,17 @@ SOURCES += displayboard.cpp \
+     preferences.cpp
+ 
+ unix*:!macx-* {
+-    QGO_INSTALL_PATH = /usr/share/qgo
+-    QGO_INSTALL_BIN_PATH = /usr/bin
++    QGO_INSTALL_PATH = $$PREFIX/share/qgo
++    QGO_INSTALL_BIN_PATH = $$PREFIX/bin
+ 
+-    icon.path = /usr/share/pixmaps
++    icon.path = $$PREFIX/share/pixmaps
+     icon.files = resources/pics/qgo.png
+     icon.files += resources/pics/qgo_16x16.xpm
+     icon.files += resources/pics/qgo_32x32.xpm
+     icon.files += resources/pics/qgo_48x48.png
+     icon.files += resources/pics/qgo_48x48.xpm
+     INSTALLS += icon
+-    desktopfile.path = /usr/share/applications
++    desktopfile.path = $$PREFIX/share/applications/
+     desktopfile.files = qgo.desktop
+     INSTALLS += desktopfile
+ }
+-- 
+2.33.1
+


### PR DESCRIPTION
    qGo is a Go Client (IGS, WING, LGS, WBaduk/CyberORO, Tygem, Tom, and eWeiqi) based on Qt 5.

Log: add software name--qgo
![qgo](https://github.com/linuxdeepin/linglong-hub/assets/147463620/553a7524-ff7c-400e-a370-430b1c2b42eb)
