### PR TITLE
build: add rssguard-debian

### DIFF
--- a/io.github.rssguard-debian/linglong.yaml
+++ b/io.github.rssguard-debian/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.rssguard-debian
+  name: rssguard-debian
+  version: 4.0.2
+  kind: app
+  description: |
+    Debian packaging of RSS Guard
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/norbusan/rssguard-debian.git
+  commit: 6ef5274e2c377a0a24a9b2fc8a65592ccfa7bfb8
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Debian packaging of RSS Guard

Log: add software name--rssguard-debian
![rssguard-debian](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7402b0a9-f036-4836-b9ad-433c3c552d1d)
