### PR TITLE
build: add qpdftools

### DIFF
--- a/io.github.qpdftools/linglong.yaml
+++ b/io.github.qpdftools/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.qpdftools
+  name: qpdftools
+  version: 1.4.0
+  kind: app
+  description: |
+    Qpdf Tools is an easy-to-use Qt interface for Ghostscript and QPDF
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/silash35/qpdftools.git
+  commit: 3d6b4fde69249ede8898ed838a8f3eda4810e803
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.qpdftools/patches/0001-install.patch
+++ b/io.github.qpdftools/patches/0001-install.patch
@@ -1,0 +1,47 @@
+From 7fcea851a2a8b243dde5ae9c0f09aab0cc173f96 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 22 Feb 2024 13:55:20 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt              | 8 ++++----
+ resources/qpdftools.desktop | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6442d75..e22613f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,9 +34,9 @@ target_link_libraries(qpdftools
+ 
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+ 
+-    install(TARGETS qpdftools DESTINATION /usr/bin)
+-    install(FILES resources/qpdftools.svg DESTINATION /usr/share/pixmaps)
+-    install(FILES ${QM} DESTINATION /usr/lib/qpdftools)
+-    install(FILES resources/qpdftools.desktop DESTINATION /usr/share/applications)
++    install(TARGETS qpdftools DESTINATION bin)
++    install(FILES resources/qpdftools.svg DESTINATION share/icons)
++    install(FILES ${QM} DESTINATION lib/qpdftools)
++    install(FILES resources/qpdftools.desktop DESTINATION share/applications)
+ 
+ endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+diff --git a/resources/qpdftools.desktop b/resources/qpdftools.desktop
+index 38d7b19..a6f36cf 100755
+--- a/resources/qpdftools.desktop
++++ b/resources/qpdftools.desktop
+@@ -1,9 +1,9 @@
+ [Desktop Entry]
+ Name=Qpdf Tools
+ Version=1.0
+-Exec=/usr/bin/qpdftools
++Exec=qpdftools
+ Comment=A easy-to-use Qt interface for Ghostscript and Stapler
+-Icon=/usr/share/pixmaps/qpdftools.svg
++Icon=qpdftools
+ Type=Application
+ Terminal=false
+ StartupNotify=true
+-- 
+2.33.1
+


### PR DESCRIPTION
    Qpdf Tools is an easy-to-use Qt interface for Ghostscript and QPDF

Log: add software name--qpdftools
![qpdftools](https://github.com/linuxdeepin/linglong-hub/assets/147463620/55e7eae7-f4a8-4d28-83c8-a0287b2c9a87)
