### PR TITLE
build: add DoomRunnerOA

### DIFF
--- a/io.github.DoomRunnerOA/linglong.yaml
+++ b/io.github.DoomRunnerOA/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.DoomRunnerOA
+  name: DoomRunnerOA
+  version: 1.8.2
+  kind: app
+  description: |
+    Preset-oriented graphical launcher of various ported Doom engines (an alternative to ZDL)
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ibin7777/DoomRunnerOA.git
+  commit: 1af5b4f852becd2d6165ac641a3d3406e07b84a3
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.DoomRunnerOA/patches/0001-install.patch
+++ b/io.github.DoomRunnerOA/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 4ce4523eaba8a70e2c3e7f87b78d1146fa54cd00 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 22 Feb 2024 14:56:17 +0800
+Subject: [PATCH] install
+
+---
+ DoomRunner.desktop |  4 ++--
+ DoomRunner.pro     | 11 +++++++++--
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/DoomRunner.desktop b/DoomRunner.desktop
+index ee62497..439aa07 100644
+--- a/DoomRunner.desktop
++++ b/DoomRunner.desktop
+@@ -1,8 +1,8 @@
+ [Desktop Entry]
+ Name=DoomRunner
+ Comment=Preset-oriented graphical launcher of ZDoom and derivatives
+-Exec=doomrunner
+-Icon=/usr/share/icons/doomrunner.ico
++Exec=DoomRunner
++Icon=Play
+ Type=Application
+ Categories=Game
+ X-Desktop-File-Install-Version=0.26
+diff --git a/DoomRunner.pro b/DoomRunner.pro
+index 7bac029..b86a764 100644
+--- a/DoomRunner.pro
++++ b/DoomRunner.pro
+@@ -121,5 +121,12 @@ win32:LIBS += -lole32 -luuid -ldwmapi
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
+-!isEmpty(target.path): INSTALLS += target
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
++!isEmpty(target.path): #INSTALLS += target
++
++target.path =$$PREFIX/bin
++desktop.files =DoomRunner.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = Resources/Icons/Play.png
++INSTALLS += desktop icons target
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Preset-oriented graphical launcher of various ported Doom engines (an alternative to ZDL)

Log: add software name--DoomRunnerOA
![DoomRunnerOA](https://github.com/linuxdeepin/linglong-hub/assets/147463620/bbd4a9f8-5a21-4445-a0ba-09b871d6de50)
