### PR TITLE
build: add CopyQ

### DIFF
--- a/io.github.CopyQ/linglong.yaml
+++ b/io.github.CopyQ/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.CopyQ
+  name: CopyQ
+  version: 3.12.0
+  kind: app
+  description: |
+    Clipboard manager with advanced features
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtscript/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/hluk/CopyQ.git
+  commit: 3f0c3e7368475ed576136ddf1ca7a6789359c018
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Clipboard manager with advanced features

Log: add software name--CopyQ
![CopyQ](https://github.com/linuxdeepin/linglong-hub/assets/147463620/6144e6de-223b-41eb-8112-e6b8b2c8f040)
