### PR TITLE
build: add endless-sky-editor

### DIFF
--- a/io.github.endless-sky-editor/linglong.yaml
+++ b/io.github.endless-sky-editor/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.endless-sky-editor
+  name: endless-sky-editor
+  version: 0.7.10
+  kind: app
+  description: |
+    Map editor for the Endless Sky universe.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/endless-sky/endless-sky-editor.git
+  commit: 8d43f12b10ec09ceee171cf5cb257170f8ef145c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.endless-sky-editor/patches/0001-install.patch
+++ b/io.github.endless-sky-editor/patches/0001-install.patch
@@ -1,0 +1,39 @@
+From 73ef08b569eb8c12b252ceb03f24f58f71433979 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 24 Feb 2024 14:38:51 +0800
+Subject: [PATCH] install
+
+---
+ endless-sky-editor.pro | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/endless-sky-editor.pro b/endless-sky-editor.pro
+index 5ef4a6c..821f0df 100644
+--- a/endless-sky-editor.pro
++++ b/endless-sky-editor.pro
+@@ -12,18 +12,18 @@ TARGET = endless-sky-editor
+ TEMPLATE = app
+ CONFIG += c++11
+ 
+-target.path = /usr/games/
++target.path = $$PREFIX/bin
+ INSTALLS += target
+ 
+-desktop.path = /usr/share/applications/
++desktop.path =  $$PREFIX/share/applications/
+ desktop.files = endless-sky-editor.desktop
+ INSTALLS += desktop
+ 
+-manual.path = /usr/share/man/man6/
++manual.path =  $$PREFIX/share/man/man6/
+ manual.files = endless-sky-editor.6
+ INSTALLS += manual
+ 
+-icon.path = /usr/share/icons/hicolor/48x48/apps/
++icon.path =  $$PREFIX/share/icons/hicolor/48x48/apps/
+ icon.files = endless-sky-editor.png
+ INSTALLS += icon
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    Map editor for the Endless Sky universe.

Log: add software name--endless-sky-editor
![endless-sky-editor](https://github.com/linuxdeepin/linglong-hub/assets/147463620/94064dc3-c440-4c51-beec-04f5e51bad91)
