### PR TITLE
build: add app plug

### DIFF
--- a/io.github.plug/linglong.yaml
+++ b/io.github.plug/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.plug
+  name: plug
+  version: 1.4.5
+  kind: app
+  description: |
+    Software for Fender Mustang Amps.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/offa/plug.git
+  commit: 0b36e459bc0060a9a8fcb644618758d2281664b4
+
+variables:
+  extra_args: |
+    -DPLUG_UNITTEST=OFF
+
+build:
+  kind: cmake


### PR DESCRIPTION
Software for Fender Mustang Amps.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/919b0929-0567-40c9-8c3a-3974553cdc4b)

Logs: add app name--plug