### PR TITLE
build: add app delaycut

### DIFF
--- a/io.github.delaycut/linglong.yaml
+++ b/io.github.delaycut/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.delaycut
+  name: delaycut
+  version: 1.4.3.10
+  kind: app
+  description: |
+    cuts and corrects delay in ac3 and dts files.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/darealshinji/delaycut.git
+  commit: 2c4d875e353c99dbe59bc74e0a0d42f2b7cea6ee
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp src/icon.png src/delaycut.png
+      qmake -makefile ${conf_args} ${extra_args}

--- a/io.github.delaycut/patches/fix_install.patch
+++ b/io.github.delaycut/patches/fix_install.patch
@@ -1,0 +1,20 @@
+diff --git a/delaycut.pro b/delaycut.pro
+index 7e18564..5e3e978 100644
+--- a/delaycut.pro
++++ b/delaycut.pro
+@@ -28,8 +28,12 @@ win32 {
+ !win32 {
+   QMAKE_CXXFLAGS += -Wno-unused-but-set-variable
+   RESOURCES      += src/icon_png.qrc
+-  target.path     = /usr/bin
+-  INSTALLS       += target
++  target.path     = $$PREFIX/bin
++  desktop.files  += misc/delaycut.desktop
++  desktop.path    = $$PREFIX/share/applications
++  icon.files     += src/delaycut.png
++  icon.path       = $$PREFIX/share/icons
++  INSTALLS       += target desktop icon
+ }
+ 
+ win32-g++* {
+


### PR DESCRIPTION
cuts and corrects delay in ac3 and dts files.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/70d97583-bde0-4ffb-8d5a-2955359e48ae)

Logs: add app name--delaycut