### PR TITLE
build: add app ANMP

### DIFF
--- a/io.github.ANMP/linglong.yaml
+++ b/io.github.ANMP/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.ANMP
+  name: ANMP
+  version: 10.0.0
+  kind: app
+  description: |
+    multi-channel loopable video game music player for nerds and audiophiles.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/derselbst/ANMP.git
+  commit: 2542ec674278f897e394790abf9ad81a25798ee7
+  patch:
+    - patches/fix_install.patch
+    - patches/fix_desktop.patch
+
+build:
+  kind: cmake

--- a/io.github.ANMP/patches/fix_desktop.patch
+++ b/io.github.ANMP/patches/fix_desktop.patch
@@ -1,0 +1,16 @@
+diff --git a/contrib/anmp.desktop b/contrib/anmp.desktop
+index 193ffba..cf5fa63 100755
+--- a/contrib/anmp.desktop
++++ b/contrib/anmp.desktop
+@@ -3,8 +3,8 @@
+ Name=ANMP
+ GenericName=Music Player
+ Comment=Audio Player for various formats
+-Exec=/usr/bin/anmp-qt %U
+-TryExec=/usr/bin/anmp-qt
++Exec=anmp-qt %U
++TryExec=anmp-qt
+ Terminal=true
+ Type=Application
+ Categories=AudioVideo;Audio;Player;
+

--- a/io.github.ANMP/patches/fix_install.patch
+++ b/io.github.ANMP/patches/fix_install.patch
@@ -1,0 +1,17 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f3cf60e..0f58409 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -131,10 +131,11 @@ endif(USE_OPENMPT)
+ add_library(${PROJECT_NAME})
+ target_link_libraries(${PROJECT_NAME} PUBLIC anmp-internal)
+ target_link_libraries(${PROJECT_NAME} PUBLIC ${LD_FLAGS})
+-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+ 
+ 
+ install(FILES Common/PlaylistFactory.h Common/types.h Common/Event.h Common/Nullable.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+ install(FILES InputLibraryWrapper/SongInfo.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+ install(FILES PlayerLogic/IPlaylist.h PlayerLogic/Playlist.h PlayerLogic/Player.h PlayerLogic/Config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
++install(FILES ../contrib/anmp.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+


### PR DESCRIPTION
multi-channel loopable video game music player for nerds and audiophiles.

项目没有提供icon.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/4fe5c477-9972-4f42-b952-ad75f20aa2f7)

Logs: add app name--ANMP