### PR TITLE
build: add FFaudioConverter

### DIFF
--- a/io.github.FFaudioConverter/linglong.yaml
+++ b/io.github.FFaudioConverter/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.FFaudioConverter
+  name: FFaudioConverter
+  version: 0.31.0
+  kind: app
+  description: |
+    Graphical audio convert and filter tool
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Bleuzen/FFaudioConverter.git
+  commit: af088c32fbfb711f2a42866dce751349d913d485
+
+build:
+  kind: qmake


### PR DESCRIPTION
    Graphical audio convert and filter tool

Log: add software name--FFaudioConverter
![FFaudioConverter](https://github.com/linuxdeepin/linglong-hub/assets/147463620/e1a45e19-cf9c-46d7-887a-ced291ba4b0b)
