### PR TITLE
build: add QMidiPlayer

### DIFF
--- a/io.github.QMidiPlayer/linglong.yaml
+++ b/io.github.QMidiPlayer/linglong.yaml
@@ -1,0 +1,33 @@
+package:
+  id: io.github.QMidiPlayer
+  name: QMidiPlayer
+  version: 0.8.7.2
+  kind: app
+  description: |
+    A cross-platform midi file player based on libfluidsynth and Qt.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: fluidsynth
+    type: runtime
+    version: 2.3.4
+  - id: glfw/3.3.8
+  - id: rtmidi
+    type: runtime
+    version: 4.0.0
+
+variables:
+  extra_args: |
+    -DBUILD_VISUALIZATION=OFF
+
+source:
+  kind: git
+  url: https://github.com/chirs241097/QMidiPlayer.git
+  commit: 07ee50be7c390668f8c600b8eb5805f56cf6a8a1
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.QMidiPlayer/patches/0001-install.patch
+++ b/io.github.QMidiPlayer/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From d58bed5c49137979a109ba959479fbc77a04d0b0 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 18:44:29 +0800
+Subject: [PATCH] install
+
+---
+ qmidiplayer-desktop/qmidiplayer.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qmidiplayer-desktop/qmidiplayer.desktop b/qmidiplayer-desktop/qmidiplayer.desktop
+index 2884d18..8837b14 100644
+--- a/qmidiplayer-desktop/qmidiplayer.desktop
++++ b/qmidiplayer-desktop/qmidiplayer.desktop
+@@ -5,7 +5,7 @@ Name=QMidiPlayer
+ Version=0.8.1
+ GenericName=MIDI Player
+ Comment=QMidiPlayer is a midi file player based on Fluidsynth and Qt.
+-Exec=/usr/bin/qmidiplayer
++Exec=qmidiplayer
+ Icon=qmidiplyr
+ Keywords=audio;sound;
+ Categories=Audio;AudioVideo;Midi;X-Alsa;X-Jack;Qt;
+-- 
+2.33.1
+


### PR DESCRIPTION
    A cross-platform midi file player based on libfluidsynth and Qt.

Log: add software name--QMidiPlayer
![QMidiPlayer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/06ff2021-1f06-4c06-b04e-34021139c78e)
