### PR TITLE
build: add coreimage

### DIFF
--- a/io.github.coreimage/linglong.yaml
+++ b/io.github.coreimage/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.coreimage
+  name: coreimage
+  version: 0.0.1
+  kind: app
+  description: |
+    An app of CoreApps family.CoreImage is image viewer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libcprime
+    type: runtime
+    version: 1.0.0
+    source:
+      kind: git
+      url: https://github.com/rahmanshaber/libcprime.git
+      version: master
+      commit: 499f472b8d99cecec83c1064164edea64e8ca6bb
+    build:
+      kind: qmake
+
+source:
+  kind: git
+  url: https://github.com/rahmanshaber/coreimage.git
+  commit: 9fc9ee42b49127883f45f4332f81b89e51b3dc8c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.coreimage/patches/0001-install.patch
+++ b/io.github.coreimage/patches/0001-install.patch
@@ -1,0 +1,39 @@
+From e152299916e5b90716244d695642f765d2f510c8 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 20:00:47 +0800
+Subject: [PATCH] install
+
+---
+ coreimage.desktop | 2 +-
+ coreimage.pro     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/coreimage.desktop b/coreimage.desktop
+index 5dc84c2..5b26de3 100644
+--- a/coreimage.desktop
++++ b/coreimage.desktop
+@@ -2,7 +2,7 @@
+ Name=CoreImage
+ Comment=CoreImage is image viewer from CoreApps.
+ Exec=coreimage %F
+-Icon=/usr/share/coreapps/icons/coreimage.svg
++Icon=coreimage
+ Type=Application
+ Categories=Utility;Qt;Graphics;Viewer;
+ Terminal=false
+diff --git a/coreimage.pro b/coreimage.pro
+index a9c9a13..24b62c2 100644
+--- a/coreimage.pro
++++ b/coreimage.pro
+@@ -8,7 +8,7 @@ QT       += core gui widgets concurrent
+ 
+ TARGET = coreimage
+ TEMPLATE = app
+-
++INCLUDEPATH += $${PREFIX}/include   
+ # library for theme
+ unix:!macx: LIBS += -lcprime
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    An app of CoreApps family.CoreImage is image viewer.

Log: add software name--coreimage
![coreimage](https://github.com/linuxdeepin/linglong-hub/assets/147463620/ac76d03c-124b-4f99-80c9-6a1d28795938)
