### PR TITLE
build: add corekeyboard

### DIFF
--- a/io.github.corekeyboard/linglong.yaml
+++ b/io.github.corekeyboard/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.corekeyboard
+  name: corekeyboard
+  version: 2.5.0
+  kind: app
+  description: |
+    A virtual keyboard for X11 from the CoreApps family.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://gitlab.com/cubocore/coreapps/corekeyboard.git
+  commit: 1b70d3a0114170adef1c77941865f12a6f4e25e7
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.corekeyboard/patches/0001-install.patch
+++ b/io.github.corekeyboard/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From be6ea3b50293b6bfe22e9094c17dab1a26a289e8 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 20:24:58 +0800
+Subject: [PATCH] install
+
+---
+ corekeyboard.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/corekeyboard.desktop b/corekeyboard.desktop
+index 1fd5ffe..a257ce3 100644
+--- a/corekeyboard.desktop
++++ b/corekeyboard.desktop
+@@ -2,7 +2,7 @@
+ Name=CoreKeyboard
+ Comment=A virtual keyboard for X11 from the CoreApps family.
+ Exec=corekeyboard
+-Icon=/usr/share/coreapps/icons/corekeyboard.svg
++Icon=corekeyboard
+ Type=Application
+ Categories=Qt;Utility;Accessibility;
+ Terminal=false
+-- 
+2.33.1
+


### PR DESCRIPTION
    A virtual keyboard for X11 from the CoreApps family.

Log: add software name--corekeyboard
![corekeyboard](https://github.com/linuxdeepin/linglong-hub/assets/147463620/4bb37656-f18e-4dac-bf4d-8a2717141348)
