### PR TITLE
build: add corerenamer

### DIFF
--- a/io.github.corerenamer/linglong.yaml
+++ b/io.github.corerenamer/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.corerenamer
+  name: corerenamer
+  version: 2.3.0
+  kind: app
+  description: |
+    CoreRenamer is a batch file renamer.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libcprime
+    type: runtime
+    version: 1.0.0
+    source:
+      kind: git
+      url: https://github.com/rahmanshaber/libcprime.git
+      version: master
+      commit: 499f472b8d99cecec83c1064164edea64e8ca6bb
+    build:
+      kind: qmake
+
+source:
+  kind: git
+  url: https://gitlab.com/cubocore/coreapps/corerenamer.git
+  commit: 2e150db7e6cc3cb2ae6d294c55934d46c086482b
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.corerenamer/patches/0001-install.patch
+++ b/io.github.corerenamer/patches/0001-install.patch
@@ -1,0 +1,39 @@
+From a349576ae4114aefa2c89dbb856deac0b69a86d1 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 20:42:49 +0800
+Subject: [PATCH] install
+
+---
+ corerenamer.desktop | 2 +-
+ corerenamer.pro     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/corerenamer.desktop b/corerenamer.desktop
+index 3aea8fc..b2e5a2d 100644
+--- a/corerenamer.desktop
++++ b/corerenamer.desktop
+@@ -2,7 +2,7 @@
+ Name=CoreRenamer
+ Comment=CoreRenamer is a batch file renamer from CoreApps.
+ Exec=corerenamer %F
+-Icon=/usr/share/coreapps/icons/corerenamer.svg
++Icon=corerenamer
+ Type=Application
+ Categories=Utility;Qt;
+ Terminal=false
+diff --git a/corerenamer.pro b/corerenamer.pro
+index bb5d52e..7e42f79 100644
+--- a/corerenamer.pro
++++ b/corerenamer.pro
+@@ -8,7 +8,7 @@ QT       += core gui widgets
+ 
+ TARGET = corerenamer
+ TEMPLATE = app
+-
++INCLUDEPATH += $${PREFIX}/include  
+ # library for theme
+ unix:!macx: LIBS += -lcprime
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    CoreRenamer is a batch file renamer.

Log: add software name--corerenamer
![corerenamer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/c05ad59a-4f0b-4ec1-b6b7-ace9230276b7)
