### PR TITLE
build: add coretime

### DIFF
--- a/io.github.coretime/linglong.yaml
+++ b/io.github.coretime/linglong.yaml
@@ -1,0 +1,32 @@
+package:
+  id: io.github.coretime
+  name: coretime
+  version: 2.3.0
+  kind: app
+  description: |
+    CoreTime is a time related task app
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libcprime
+    type: runtime
+    version: 1.0.0
+    source:
+      kind: git
+      url: https://github.com/rahmanshaber/libcprime.git
+      version: master
+      commit: 499f472b8d99cecec83c1064164edea64e8ca6bb
+    build:
+      kind: qmake
+
+source:
+  kind: git
+  url: https://gitlab.com/cubocore/coreapps/coretime.git
+  commit: 275373ca9b7ce974d3e8ed7f189e934420976e40
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.coretime/patches/0001-install.patch
+++ b/io.github.coretime/patches/0001-install.patch
@@ -1,0 +1,39 @@
+From 9fba9f9341626df0d3aeafa9b6b1ca9875150d67 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 21:02:05 +0800
+Subject: [PATCH] install
+
+---
+ coretime.desktop | 2 +-
+ coretime.pro     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/coretime.desktop b/coretime.desktop
+index 46852c4..3d0f86e 100644
+--- a/coretime.desktop
++++ b/coretime.desktop
+@@ -2,7 +2,7 @@
+ Name=CoreTime
+ Comment=CoreTime is a time related task app from CoreApps.
+ Exec=coretime
+-Icon=/usr/share/coreapps/icons/coretime.svg
++Icon=coretime
+ Type=Application
+ Categories=Utility;Qt;
+ Terminal=false
+diff --git a/coretime.pro b/coretime.pro
+index 71bd51d..7c31e0d 100644
+--- a/coretime.pro
++++ b/coretime.pro
+@@ -8,7 +8,7 @@ QT       += core gui widgets multimedia #multimediawidgets
+ 
+ TARGET = coretime
+ TEMPLATE = app
+-
++INCLUDEPATH += $${PREFIX}/include  
+ # library for theme
+ unix:!macx: LIBS += -lcprime
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    CoreTime is a time related task app

Log: add software name--coretime
![coretime](https://github.com/linuxdeepin/linglong-hub/assets/147463620/837182f9-d6a8-4acf-abc1-4a1bab0c80db)
