### PR TITLE
build: add app DiskImagery64

### DIFF
--- a/io.github.DiskImagery64/linglong.yaml
+++ b/io.github.DiskImagery64/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.DiskImagery64
+  name: DiskImagery64
+  version: 0.0.1
+  kind: app
+  description: |
+    A portable drag & drop D64 Disk Image Editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ProbablyNotArtyom/DiskImagery64.git
+  commit: 32ee2eec3bd31961ff3a6760a3d4f702100474ab
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake

--- a/io.github.DiskImagery64/patches/fix_install.patch
+++ b/io.github.DiskImagery64/patches/fix_install.patch
@@ -1,0 +1,22 @@
+diff --git a/imagery/imagery.pro b/imagery/imagery.pro
+index c0ec12e..8adbbe4 100644
+--- a/imagery/imagery.pro
++++ b/imagery/imagery.pro
+@@ -37,13 +37,13 @@ win32 {
+ }
+ 
+ unix {
+-    icon.path = /usr/share/pixmaps
++    icon.path = $$PREFIX/share/pixmaps
+     icon.files = ../icons/imagery/imagery.xpm
+     icon.uninstall = @echo "uninstall"
+-    desktop.path = /usr/share/applications
++    desktop.path = $$PREFIX/share/applications
+     desktop.files = ../icons/imagery/diskimagery64.desktop
+     desktop.uninstall = @echo "uninstall"
+-    target.path = /usr/local/bin
++    target.path = $$PREFIX/bin
+     target.files = diskimagery64
+     target.uninstall = @echo "uninstall"
+ 
+


### PR DESCRIPTION
A portable drag & drop D64 Disk Image Editor.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/77ca0f31-6a14-4074-962a-8c2e384e0032)

Logs: add app name--DiskImagery64