### PR TITLE
build: add app PKGBUILD-Assistant

### DIFF
--- a/io.github.PKGBUILD-Assistant/linglong.yaml
+++ b/io.github.PKGBUILD-Assistant/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.PKGBUILD-Assistant
+  name: PKGBUILD-Assistant
+  version: 2.2.0
+  kind: app
+  description: |
+    An auxiliary tool for writing PKGBUILD files written in Qt5.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/skykeyjoker/PKGBUILD-Assistant.git
+  commit: ccaaba8059dd5d3b0f3f0efdb98c4533dc32bde9
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp ico.png pkgbuild-assistant.png
+      qmake -makefile ${conf_args} ${extra_args}

--- a/io.github.PKGBUILD-Assistant/patches/fix_install.patch
+++ b/io.github.PKGBUILD-Assistant/patches/fix_install.patch
@@ -1,0 +1,32 @@
+diff --git a/PKGBUILD_ASSISTANT.pro b/PKGBUILD_ASSISTANT.pro
+index ba34cbc..421d7f5 100644
+--- a/PKGBUILD_ASSISTANT.pro
++++ b/PKGBUILD_ASSISTANT.pro
+@@ -37,8 +37,13 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: target.path = $$PREFIX/bin
+ !isEmpty(target.path): INSTALLS += target
++desktop.files = pkgbuild-assistant.desktop
++desktop.path = $$PREFIX/share/applications
++icon.files = pkgbuild-assistant.png
++icon.path = $$PREFIX/share/icons
++INSTALLS += desktop icon
+ 
+ RESOURCES += \
+     res.qrc
+diff --git a/pkgbuild-assistant.desktop b/pkgbuild-assistant.desktop
+index 9fc2b9a..08cb9f7 100644
+--- a/pkgbuild-assistant.desktop
++++ b/pkgbuild-assistant.desktop
+@@ -2,7 +2,7 @@
+ Name=PKGBUILD Assistant
+ Comment=An auxiliary tool for writing PKGBUILD files developed using the Qt5 framework.
+ GenericName=PKGBUILD Assistant
+-Exec=pkgbuild-assistant
++Exec=PKGBUILD_ASSISTANT
+ Icon=pkgbuild-assistant
+ StartupNotify=true
+ Terminal=false


### PR DESCRIPTION
An auxiliary tool for writing PKGBUILD files written in Qt5

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/3cb62696-11c4-4a46-93bb-b4ab0a26b84f)

Logs: add app name--PKGBUILD-Assistant