### PR TITLE
build: add app artmoo

### DIFF
--- a/io.github.artmoo/linglong.yaml
+++ b/io.github.artmoo/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.artmoo
+  name: artmoo
+  version: 1.0.1.1
+  kind: app
+  description: |
+    A telnet/websocket Multi-user Object Orientated (MOO) server for creating text-only art projects and virtual worlds.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/bigfug/moo.git
+  commit: a6f1325a19f4e5f33cc236ee0274ee34390e74fe
+  patch:
+    - patches/fix_desktop.patch
+
+build:
+  kind: cmake

--- a/io.github.artmoo/patches/fix_desktop.patch
+++ b/io.github.artmoo/patches/fix_desktop.patch
@@ -1,0 +1,12 @@
+diff --git a/Server/artmoo-server.desktop b/Server/artmoo-server.desktop
+index 8326c91..ff9b0a2 100644
+--- a/Server/artmoo-server.desktop
++++ b/Server/artmoo-server.desktop
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Exec=artmoo-server
+-Icon=usr/share/icons/hicolor/512x512/apps/artmoo-server.png
++Icon=artmoo-server
+ Version=1.0.0
+ Name=ArtMOO
+ Terminal=false


### PR DESCRIPTION
A telnet/websocket Multi-user Object Orientated (MOO) server for creating text-only art projects and virtual worlds.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/c185da3c-dcd6-4eae-bb1e-de4815671860)

Logs: add app name--artmoo