### PR TITLE
build: add app vatsinator-legacy

### DIFF
--- a/io.github.vatsinator-legacy/linglong.yaml
+++ b/io.github.vatsinator-legacy/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.vatsinator-legacy
+  name: vatsinator-legacy
+  version: 0.3.0.3
+  kind: app
+  description: |
+    An open-source Vatsim monitor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Vatsinator/vatsinator-legacy.git
+  commit: f80c21059afb89e8baec154283d3e8f12c62db30
+  patch:
+    - patches/fix_desktop.patch
+
+build:
+  kind: cmake
+  manual:
+    install: |
+      env DESTDIR=${dest_dir} cmake --build ${build_dir} --target install
+      chmod +x ${PREFIX}/lib/vatsinator/*

--- a/io.github.vatsinator-legacy/patches/fix_desktop.patch
+++ b/io.github.vatsinator-legacy/patches/fix_desktop.patch
@@ -1,0 +1,16 @@
+diff --git a/src/application/widgets/dist/vatsinator.desktop.in b/src/application/widgets/dist/vatsinator.desktop.in
+index 07e6e3b3..7893356c 100644
+--- a/src/application/widgets/dist/vatsinator.desktop.in
++++ b/src/application/widgets/dist/vatsinator.desktop.in
+@@ -4,8 +4,8 @@ Type=Application
+ Name=Vatsinator
+ GenericName=Vatsim monitor
+ Comment=A simple Vatsim monitor
+-TryExec=${CMAKE_INSTALL_PREFIX}/bin/vatsinator
+-Exec=${CMAKE_INSTALL_PREFIX}/bin/vatsinator
++TryExec=env LD_LIBRARY_PATH=$LD_LIBRARY_PATH:@CMAKE_INSTALL_PREFIX@/lib/vatsinator/ vatsinator
++Exec=env LD_LIBRARY_PATH=$LD_LIBRARY_PATH:@CMAKE_INSTALL_PREFIX@/lib/vatsinator/ vatsinator
+ Categories=Network;Qt;
+ Icon=vatsinator
+ 
+


### PR DESCRIPTION
An open-source Vatsim monitor.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/93ffa268-33e7-4238-b4f7-0002ac2da3d9)

Logs: add app name--vatsinator-legacy