### PR TITLE
build: add corehelp

### DIFF
--- a/io.github.corehelp/linglong.yaml
+++ b/io.github.corehelp/linglong.yaml
@@ -1,0 +1,31 @@
+package:
+  id: io.github.corehelp
+  name: corehelp
+  version: 2.3.0
+  kind: app
+  description: |
+    Help app for CoreApps related help documents.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libcprime
+    type: runtime
+    version: 1.0.0
+    source:
+      kind: git
+      url: https://github.com/rahmanshaber/libcprime.git
+      version: master
+      commit: 499f472b8d99cecec83c1064164edea64e8ca6bb
+    build:
+      kind: qmake
+
+source:
+  kind: git
+  url: https://github.com/rahmanshaber/help.git
+  commit: fa67e53a2c833bd0568e57cedc13ff9d48e0be80
+  patch: patches/0001-install.patch
+build:
+  kind: qmake

--- a/io.github.corehelp/patches/0001-install.patch
+++ b/io.github.corehelp/patches/0001-install.patch
@@ -1,0 +1,39 @@
+From 81fede1b9604c8a203e6b282d93f57598f85910f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 25 Feb 2024 21:36:36 +0800
+Subject: [PATCH] install
+
+---
+ help coreapps.desktop | 2 +-
+ help.pro              | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/help coreapps.desktop b/help coreapps.desktop
+index efdf3e3..c7f6446 100644
+--- a/help coreapps.desktop	
++++ b/help coreapps.desktop	
+@@ -2,7 +2,7 @@
+ Name=Help CoreApps
+ Comment=Help app for CoreApps related help
+ Exec=help
+-Icon=/usr/share/coreapps/icons/help.svg
++Icon=help
+ Type=Application
+ Categories=Utility;Core;Qt;Documentation;
+ Terminal=false
+diff --git a/help.pro b/help.pro
+index d0a3d94..74a9a0e 100644
+--- a/help.pro
++++ b/help.pro
+@@ -8,7 +8,7 @@ QT       += core gui widgets
+ 
+ TARGET = help
+ TEMPLATE = app
+-
++INCLUDEPATH += $${PREFIX}/include
+ # library for theme
+ unix:!macx: LIBS += -lcprime
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    Help app for CoreApps related help documents.

Log: add software name--corehelp
![Corehelp](https://github.com/linuxdeepin/linglong-hub/assets/147463620/2e041159-918b-4055-84e0-d291f8e21e50)
