### PR TITLE
build: add AssistantQt

### DIFF
--- a/io.github.AssistantQt/linglong.yaml
+++ b/io.github.AssistantQt/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.AssistantQt
+  name: AssistantQt
+  version: 0.0.3
+  kind: app
+  description: |
+    Assistant is a delightful files mod tool
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/keygenqt/AssistantQt.git
+  commit: 296500ba3c05d35c21d81c1d30198541a36ebb9c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd assistantQt
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.AssistantQt/patches/0001-install.patch
+++ b/io.github.AssistantQt/patches/0001-install.patch
@@ -1,0 +1,49 @@
+From 0aa7c72867abd64027e6841d3846313bb53d4ee5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 26 Feb 2024 16:59:50 +0800
+Subject: [PATCH] install
+
+---
+ assistantQt/assistantQt.pro | 9 ++++++++-
+ gui/kg-assistantqt.desktop  | 4 ++--
+ 2 files changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/assistantQt/assistantQt.pro b/assistantQt/assistantQt.pro
+index eb3d1fe..c56b414 100644
+--- a/assistantQt/assistantQt.pro
++++ b/assistantQt/assistantQt.pro
+@@ -35,8 +35,15 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
++target.path =$$PREFIX/bin
++desktop.files =../gui/kg-assistantqt.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../gui/kg-assistantqt.png
++INSTALLS += target desktop icons
++
+ RESOURCES += \
+     data/resources.qrc
+diff --git a/gui/kg-assistantqt.desktop b/gui/kg-assistantqt.desktop
+index 2e37d16..9335190 100644
+--- a/gui/kg-assistantqt.desktop
++++ b/gui/kg-assistantqt.desktop
+@@ -4,8 +4,8 @@ Name=AssistantQt
+ GenericName=AssistantQt
+ Comment=AssistantQt open source gui for console application Assistant
+ Keywords=utils
+-Exec=kg-assistantqt
+-Icon=${SNAP}/images/kg-assistantqt.png
++Exec=assistantQt
++Icon=kg-assistantqt
+ Terminal=false
+ Type=Application
+ Categories=Utility;
+-- 
+2.33.1
+


### PR DESCRIPTION
    Assistant is a delightful files mod tool

Log: add software name--AssistantQt
![AssistantQt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b6971246-8a48-45a7-ba54-49720dc3f83b)
