### PR TITLE
build: add voicegen

### DIFF
--- a/io.github.voicegen/linglong.yaml
+++ b/io.github.voicegen/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.voicegen
+  name: voicegen
+  version: 1.0.5
+  kind: app
+  description: |
+    VoiceGen is a simple but powerful text to speech application, with support for multiple offline/online engines such as svox and Amazon Polly.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://gitlab.com/PersianGolf/voicegen.git
+  commit: e262221d8ea461748c7d029e151429fd6122013f
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.voicegen/patches/0001-install.patch
+++ b/io.github.voicegen/patches/0001-install.patch
@@ -1,0 +1,38 @@
+From d84c0b6465936a944bdf20c5d6105a218fd3b65a Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 27 Feb 2024 19:14:24 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt            | 6 ++++++
+ snap/gui/voicegen.desktop | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8324ed2..90ed176 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,3 +32,9 @@ target_link_libraries(voicegen Qt5::Widgets Qt5::Multimedia)
+ # Install the executable
+ install(TARGETS voicegen DESTINATION bin)
+ 
++install(FILES snap/gui/voicegen.svg
++        DESTINATION share/icons)
++
++
++install(FILES snap/gui/voicegen.desktop
++            DESTINATION share/applications)
+\ No newline at end of file
+diff --git a/snap/gui/voicegen.desktop b/snap/gui/voicegen.desktop
+index 5d6dcbb..5d2db3c 100755
+--- a/snap/gui/voicegen.desktop
++++ b/snap/gui/voicegen.desktop
+@@ -8,4 +8,4 @@ Terminal=false
+ Exec=voicegen
+ Keywords=Speech;Streamlabs;tts;svox;
+ Categories=Utility;
+-Icon=${SNAP}/meta/gui/voicegen.svg
++Icon==voicegen
+-- 
+2.33.1
+


### PR DESCRIPTION
    VoiceGen is a simple but powerful text to speech application, with support for multiple offline/online engines such as svox and Amazon Polly.

Log: add software name--voicegen
![voicegen](https://github.com/linuxdeepin/linglong-hub/assets/147463620/534078e8-73fc-45f5-a5d9-2c4c4b17ab76)
