### PR TITLE
build: add vnote

### DIFF
--- a/io.github.vnote/linglong.yaml
+++ b/io.github.vnote/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.vnote
+  name: vnote
+  version: 3.17.0
+  kind: app
+  description: |
+    A pleasant note-taking platform.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtwebengine/5.15.7
+
+source:
+  kind: git
+  url: https://github.com/vnotex/vnote.git
+  commit: daa2fe1785187a302b5412cec84044ba51f0ae5e
+
+build:
+  kind: qmake


### PR DESCRIPTION
    A pleasant note-taking platform.

Log: add software name--vnote
![vnote](https://github.com/linuxdeepin/linglong-hub/assets/147463620/beb23e60-1551-4f72-b06d-0f56f1b19e44)
