### PR TITLE
build: add zint

### DIFF
--- a/io.github.zint/linglong.yaml
+++ b/io.github.zint/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.zint
+  name: zint
+  version: 2.5.0
+  kind: app
+  description: |
+    Zint is a suite of programs to allow easy encoding of data in any of the wide range of public domain barcode standards and to allow integration ofthis capability into your own programs.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/hmyit/zint-sf.git
+  commit: bcec2718ee9deabd2e28e61ba9db33977242cbbf
+  patch: 
+    - patches/0001-install.patch
+    - patches/0002-install.patch
+
+build:
+  kind: cmake

--- a/io.github.zint/patches/0001-install.patch
+++ b/io.github.zint/patches/0001-install.patch
@@ -1,0 +1,28 @@
+From d07a8ebac864a24e42214f4f5dc7ba4d4eddd57f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 27 Feb 2024 20:04:42 +0800
+Subject: [PATCH] install
+
+---
+ frontend_qt/CMakeLists.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/frontend_qt/CMakeLists.txt b/frontend_qt/CMakeLists.txt
+index 5eef524..c911771 100644
+--- a/frontend_qt/CMakeLists.txt
++++ b/frontend_qt/CMakeLists.txt
+@@ -23,3 +23,10 @@ link_directories( "${CMAKE_BINARY_DIR}/backend" "${CMAKE_BINARY_DIR}/backend_qt"
+ target_link_libraries(zint-qt zint QZint Qt5::UiTools ${QT_QTXML_LIBRARY} Qt5::Gui Qt5::Core )
+ 
+ install(TARGETS zint-qt DESTINATION "${BIN_INSTALL_DIR}" RUNTIME)
++
++install(FILES ../zint.png
++        DESTINATION share/icons)
++
++
++install(FILES ../zint-qt.desktop
++            DESTINATION share/applications)
+\ No newline at end of file
+-- 
+2.33.1
+

--- a/io.github.zint/patches/0002-install.patch
+++ b/io.github.zint/patches/0002-install.patch
@@ -1,0 +1,25 @@
+From 6d03ae2d4de3ed9af03a8283a3ce9b5bcd44b2ff Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 27 Feb 2024 20:00:58 +0800
+Subject: [PATCH] install
+
+---
+ backend_qt/qzint.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/backend_qt/qzint.cpp b/backend_qt/qzint.cpp
+index d0069eb..4a82c5c 100644
+--- a/backend_qt/qzint.cpp
++++ b/backend_qt/qzint.cpp
+@@ -17,7 +17,7 @@
+ 
+ #include "qzint.h"
+ #include <stdio.h>
+-
++#include <QPainterPath>
+ namespace Zint {
+ 
+     static const qreal maxi_diagonal = 11;
+-- 
+2.33.1
+


### PR DESCRIPTION
    Zint is a suite of programs to allow easy encoding of data in any of the wide range of public domain barcode standards and to allow integration ofthis capability into your own programs.

Log: add software name--zint
![zint](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7dd3c834-a27e-4d35-b913-8c94c02dd401)
