### PR TITLE
build: add app goat

### DIFF
--- a/io.github.goat/linglong.yaml
+++ b/io.github.goat/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.goat
+  name: goat
+  version: 1.0.1.1
+  kind: app
+  description: |
+    Database frontend written in QT5 using widgets. At some point it should provide an alternative to tools like mysql workbench and pgadmin.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/mispp/goat.git
+  commit: fec86223ab38888537c458f62cd62ddea534037b
+  patch:
+    - patches/fix_install.patch
+
+build:
+  kind: cmake

--- a/io.github.goat/patches/fix_install.patch
+++ b/io.github.goat/patches/fix_install.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8b36ae4..c97000c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,3 +70,7 @@ target_link_libraries(
+     Qt5::Sql
+     Qt5::Widgets
+ )
++
++install(TARGETS Goat DESTINATION bin)
++install(FILES packaging/goat.desktop DESTINATION share/applications)
++install(FILES packaging/goat.png DESTINATION share/icons)
+diff --git a/packaging/goat.desktop b/packaging/goat.desktop
+index 55cc0c4..082cee3 100644
+--- a/packaging/goat.desktop
++++ b/packaging/goat.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Categories=Office;Database;Qt;KDE;
+ StartupNotify=true
+-Exec=/usr/bin/goat
++Exec=Goat
+ Name=Goat
+ GenericName=Goat database management
+ Terminal=false


### PR DESCRIPTION
Database frontend written in QT5 using widgets. At some point it should provide an alternative to tools like mysql workbench and pgadmin.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/91e159fe-4499-4fdc-a038-97190cc28e54)

Logs: add app name--goat