### PR TITLE
build: add app fingerboard

### DIFF
--- a/io.github.fingerboard/linglong.yaml
+++ b/io.github.fingerboard/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.fingerboard
+  name: fingerboard
+  version: 0.2.2
+  kind: app
+  description: |
+    A fprintd based fingerprint GUI for Linux.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/anupam-git/fingerboard.git
+  commit: 41f8a5bc8c74dca86ac9147226eb25a87f7e8b57
+
+build:
+  kind: cmake


### PR DESCRIPTION
A fprintd based fingerprint GUI for Linux.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/d675f4b6-2b5b-482e-bb37-5460689b422d)

Logs: add app name--fingerboard