### PR TITLE
build: add app hswitch

### DIFF
--- a/io.github.hswitch/linglong.yaml
+++ b/io.github.hswitch/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.hswitch
+  name: hswitch
+  version: 22.12.0
+  kind: app
+  description: |
+    hosts file content switcher.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/pbek/hswitch.git
+  commit: 6977475c57f3fd9cf417d2a7de0a0ab301690a9e
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile ${conf_args} ${extra_args}


### PR DESCRIPTION
hosts file content switcher.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/007ab1e7-b0e1-4ee9-8082-a0143bd06524)

Logs: add app name--hswitch