### PR TITLE
build: add app qfm1000

### DIFF
--- a/io.github.qfm1000/linglong.yaml
+++ b/io.github.qfm1000/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.qfm1000
+  name: qfm1000
+  version: 0.7.1
+  kind: app
+  description: |
+    Philips FM1000 EEPROM channels and configuration parameters editor.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/sardylan/qfm1000.git
+  commit: 0f265bc34571976acd7eed33abdf68eccf6899bf
+
+build:
+  kind: cmake


### PR DESCRIPTION
Philips FM1000 EEPROM channels and configuration parameters editor.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/30671a8c-f67e-47a7-aeb8-752f38009831)

Logs: add app name--qfm1000