### PR TITLE
build: add parallel-launcher

### DIFF
--- a/io.github.parallel-launcher/linglong.yaml
+++ b/io.github.parallel-launcher/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.parallel-launcher
+  name: parallel-launcher
+  version: 7.2.0
+  kind: app
+  description: |
+    A simple easy-to-use launcher for the ParallelN64 emulator
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://gitlab.com/parallel-launcher/parallel-launcher.git
+  commit: 05f40d0e3783a60c54f4961ce5a11c08437d778d
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp appicon.icns ca.parallel_launcher.ParallelLauncher.png
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.parallel-launcher/patches/0001-install.patch
+++ b/io.github.parallel-launcher/patches/0001-install.patch
@@ -1,0 +1,29 @@
+From e3a6224fa120038c1b2692043b04a7530b607d25 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 1 Mar 2024 12:49:02 +0800
+Subject: [PATCH] install
+
+---
+ app.pro | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/app.pro b/app.pro
+index 8337d1d..27eab2d 100644
+--- a/app.pro
++++ b/app.pro
+@@ -172,3 +172,11 @@ flatpak-version {
+ 
+ 	INSTALLS = inst_bin inst_desktop
+ }
++
++target.path =$$PREFIX/bin
++desktop.files =ca.parallel_launcher.ParallelLauncher.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ca.parallel_launcher.ParallelLauncher.png
++
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    A simple easy-to-use launcher for the ParallelN64 emulator

Log: add software name--parallel-launcher
![parallel-launcher](https://github.com/linuxdeepin/linglong-hub/assets/147463620/4e129dfe-5b53-4c77-8769-8545e44a06cf)
