### PR TITLE
build: add VMPK

### DIFF
--- a/io.github.VMPK/linglong.yaml
+++ b/io.github.VMPK/linglong.yaml
@@ -1,0 +1,31 @@
+package:
+  id: io.github.VMPK
+  name: VMPK
+  version: 0.7.2
+  kind: app
+  description: |
+    Virtual MIDI Piano Keyboard 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: drumstick
+    type: runtime
+    version: 1.1.3
+    source:
+      kind: git
+      url: https://github.com/pedrolcl/drumstick.git
+      version: master
+      commit: ba30c88dd09ca3c22e61fdb0d56eb107bfff18e5
+    build:
+      kind: cmake
+
+source:
+  kind: git
+  url: https://github.com/pedrolcl/VMPK.git
+  commit: 5b102ae7a7848da3106cce2943742aff2303212f
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Virtual MIDI Piano Keyboard

Log: add software name--VMPK
![VMPK](https://github.com/linuxdeepin/linglong-hub/assets/147463620/584815de-032b-4511-a98c-657b45b89893)
