### PR TITLE
build: add OpenKJ

### DIFF
--- a/io.github.OpenKJ/linglong.yaml
+++ b/io.github.OpenKJ/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.OpenKJ
+  name: OpenKJ
+  version: 2.0.0.1
+  kind: app
+  description: |
+    Open source karaoke show hosting software.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/OpenKJ/OpenKJ.git
+  commit: 674e14a76db9d9829875dc2b95374918aff399b0
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake
+ 

--- a/io.github.OpenKJ/patches/0001-install.patch
+++ b/io.github.OpenKJ/patches/0001-install.patch
@@ -1,0 +1,26 @@
+From 1df6a34dbd193f9047f857c5058c56805ef62057 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 27 Mar 2024 20:18:35 +0800
+Subject: [PATCH] install
+
+---
+ src/openkj.desktop | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/openkj.desktop b/src/openkj.desktop
+index 72cdb3e..2cb6ec7 100644
+--- a/src/openkj.desktop
++++ b/src/openkj.desktop
+@@ -3,7 +3,7 @@ Type=Application
+ Version=1.0
+ Name=OpenKJ
+ Comment=Karaoke Hosting Software
+-Exec=env QT_QPA_PLATFORM=xcb /usr/bin/openkj
+-Icon=/usr/share/pixmaps/okjicon.svg
++Exec=env QT_QPA_PLATFORM=xcb openkj
++Icon=okjicon
+ Terminal=false
+ Categories=AudioVideo;Audio;Player;
+-- 
+2.33.1
+


### PR DESCRIPTION
    Open source karaoke show hosting software.

Log: add software name--OpenKJ
![OpenKJ](https://github.com/linuxdeepin/linglong-hub/assets/147463620/dbe71d24-254d-4d34-af0b-78a6571ad98d)
