### PR TITLE
build: add LibreCAD

### DIFF
--- a/io.github.LibreCAD/linglong.yaml
+++ b/io.github.LibreCAD/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.LibreCAD
+  name: LibreCAD
+  version: 2.2.0.2
+  kind: app
+  description: |
+    LibreCAD is a cross-platform 2D CAD program written in C++17 using the Qt framework.
+ 
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/LibreCAD/LibreCAD.git
+  commit: f21fde6e5ee4a63b68e72ad59a3fa4268dbe1314
+  patch: 
+    - patches/0001-install.patch
+    - patches/0002-install.patch
+    - patches/0003-install.patch
+
+build:
+  kind: qmake
+  

--- a/io.github.LibreCAD/patches/0001-install.patch
+++ b/io.github.LibreCAD/patches/0001-install.patch
@@ -1,0 +1,53 @@
+From 5702eec692455f323e78995d2d66b1e5aafc2380 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 12 Mar 2024 16:20:00 +0800
+Subject: [PATCH] install
+ 
+---
+ librecad/src/lib/engine/lc_splinepoints.cpp | 2 +-
+ librecad/src/lib/engine/rs_hatch.cpp        | 2 +-
+ librecad/src/lib/gui/rs_painterqt.cpp       | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/librecad/src/lib/engine/lc_splinepoints.cpp b/librecad/src/lib/engine/lc_splinepoints.cpp
+index f811e525..7fbf823b 100644
+--- a/librecad/src/lib/engine/lc_splinepoints.cpp
++++ b/librecad/src/lib/engine/lc_splinepoints.cpp
+@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ 
+ #include <QPolygonF>
+ #include "lc_splinepoints.h"
+-
++#include<QPainterPath>
+ #include "rs_circle.h"
+ #include "rs_debug.h"
+ #include "rs_line.h"
+diff --git a/librecad/src/lib/engine/rs_hatch.cpp b/librecad/src/lib/engine/rs_hatch.cpp
+index 0dbc4e54..a81e493f 100644
+--- a/librecad/src/lib/engine/rs_hatch.cpp
++++ b/librecad/src/lib/engine/rs_hatch.cpp
+@@ -30,7 +30,7 @@
+ #include <QBrush>
+ #include <QString>
+ #include "rs_hatch.h"
+-
++#include<QPainterPath>
+ #include "rs_arc.h"
+ #include "rs_circle.h"
+ #include "rs_ellipse.h"
+diff --git a/librecad/src/lib/gui/rs_painterqt.cpp b/librecad/src/lib/gui/rs_painterqt.cpp
+index bc3f6552..722de932 100644
+--- a/librecad/src/lib/gui/rs_painterqt.cpp
++++ b/librecad/src/lib/gui/rs_painterqt.cpp
+@@ -28,7 +28,7 @@
+ #include "rs_painterqt.h"
+ #include "rs_math.h"
+ #include "rs_debug.h"
+-
++#include<QPainterPath>
+ namespace {
+ /**
+  * Wrapper for Qt
+-- 
+2.33.1
+

--- a/io.github.LibreCAD/patches/0002-install.patch
+++ b/io.github.LibreCAD/patches/0002-install.patch
@@ -1,0 +1,25 @@
+From ad7c080daede31f90c98acf05f7ae975341909ba Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 12 Mar 2024 16:25:12 +0800
+Subject: [PATCH] install
+ 
+---
+ librecad/src/ui/generic/widgetcreator.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/librecad/src/ui/generic/widgetcreator.cpp b/librecad/src/ui/generic/widgetcreator.cpp
+index ca89ab13..4c23d745 100644
+--- a/librecad/src/ui/generic/widgetcreator.cpp
++++ b/librecad/src/ui/generic/widgetcreator.cpp
+@@ -30,7 +30,7 @@
+ #include <QSettings>
+ #include <QLineEdit>
+ #include <QPushButton>
+-
++#include <QActionGroup>
+ WidgetCreator::WidgetCreator(QWidget* parent,
+                              QMap<QString, QAction*>& actions,
+                              QMap<QString, QActionGroup*> action_groups,
+-- 
+2.33.1
+

--- a/io.github.LibreCAD/patches/0003-install.patch
+++ b/io.github.LibreCAD/patches/0003-install.patch
@@ -1,0 +1,29 @@
+From 9bdd1a05da3a7681f3d6cb3b04e0bce5973dd27a Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Tue, 12 Mar 2024 16:32:04 +0800
+Subject: [PATCH] install
+ 
+---
+ librecad/src/src.pro | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/librecad/src/src.pro b/librecad/src/src.pro
+index 94d63cf4..c7d3744f 100644
+--- a/librecad/src/src.pro
++++ b/librecad/src/src.pro
+@@ -982,3 +982,11 @@ TRANSLATIONS = ../ts/librecad_ar.ts \
+     ../ts/librecad_uk.ts \
+     ../ts/librecad_zh_cn.ts \
+     ../ts/librecad_zh_tw.ts
++
++
++target.path =$$PREFIX/bin
++desktop.files =../../desktop/librecad.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../librecad/res/main/librecad.png
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    LibreCAD is a cross-platform 2D CAD program written in C++17 using the Qt framework.

Log: add software name--LibreCAD
![LibreCAD](https://github.com/linuxdeepin/linglong-hub/assets/147463620/00fbb8a4-8272-42a0-a9d6-faacce061099)
