### PR TITLE
build: add pineapple-chapter-tool

### DIFF
--- a/io.github.pineapple-chapter-tool/linglong.yaml
+++ b/io.github.pineapple-chapter-tool/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.pineapple-chapter-tool
+  name: pineapple-chapter-tool
+  version: 1.0.0
+  kind: app
+  description: |
+    Tool for adding chapter markers to audio files.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: taglib/1.12.0
+
+source:
+  kind: git
+  url: https://github.com/BLumia/pineapple-chapter-tool.git
+  commit: 0f9251931b4e0fd7949bc3b3a3097bc9d3ae0be2
+build:
+  kind: cmake

--- a/io.github.pineapple-chapter-tool/patches/0001-install.patch
+++ b/io.github.pineapple-chapter-tool/patches/0001-install.patch
@@ -1,0 +1,31 @@
+From 821e51f6a4381ab49894a4d40347e25062068d74 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 13 Mar 2024 18:59:27 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fba74bc..3bf9bba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -63,3 +63,13 @@ target_link_libraries(thplayer thtk Qt5::Widgets Qt5::Multimedia)
+ if(WIN32)
+     set_property(TARGET thplayer PROPERTY WIN32_EXECUTABLE True)
+ endif()
++
++install(TARGETS ${PROJECT_NAME}
++             DESTINATION bin)
++
++install(FILES assets/thplayer.svg
++        DESTINATION share/icons)
++
++
++install(FILES assets/thplayer.desktop
++            DESTINATION share/applications)
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Tool for adding chapter markers to audio files.

Log: add software name--pineapple-chapter-tool
![pineapple-chapter-tool](https://github.com/linuxdeepin/linglong-hub/assets/147463620/0d5df629-9031-4159-9a26-a9a038500a98)
