### PR TITLE
build: add crwx-ng

### DIFF
--- a/io.github.crwx-ng/linglong.yaml
+++ b/io.github.crwx-ng/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.crwx-ng	
+  name: crwx-ng
+  version: 0.3.1
+  kind: app
+  description: |
+    crwx-ng - cross-platform open source e-book reader 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: wxWidgets/3.2.3
+    type: runtime
+  - id: crengine-ng/0.9.10
+    type: runtime
+
+source:
+  kind: git
+  url: https://gitlab.com/coolreader-ng/crwx-ng.git
+  commit: 72e7eca541ec21adc606a41041e19663c28d2db0
+
+build:
+  kind: cmake

--- a/io.github.crwx-ng/patches/0001-install.patch
+++ b/io.github.crwx-ng/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From 6ae11fdc3cceebe6ee14cfa25ed7579a1d1ad910 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 17 Mar 2024 11:21:51 +0800
+Subject: [PATCH] install
+
+---
+ third_party/poco/Crypto/src/RSACipherImpl.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/third_party/poco/Crypto/src/RSACipherImpl.cpp b/third_party/poco/Crypto/src/RSACipherImpl.cpp
+index 5c2e493..3f93e9d 100755
+--- a/third_party/poco/Crypto/src/RSACipherImpl.cpp
++++ b/third_party/poco/Crypto/src/RSACipherImpl.cpp
+@@ -51,7 +51,7 @@ namespace
+ 		case RSA_PADDING_PKCS1_OAEP:
+ 			return RSA_PKCS1_OAEP_PADDING;
+ 		case RSA_PADDING_SSLV23:
+-			return RSA_SSLV23_PADDING;
++			return 2;
+ 		case RSA_PADDING_NONE:
+ 			return RSA_NO_PADDING;
+ 		default:
+-- 
+2.33.1
+


### PR DESCRIPTION
    crwx-ng - cross-platform open source e-book reader

Log: add software name--crwx-ng
![crwx-ng](https://github.com/linuxdeepin/linglong-hub/assets/147463620/44601c7c-0b2e-497e-9c6d-fe9d49f29291)
