### PR TITLE
build: add Regin-QOwn

### DIFF
--- a/io.github.Regin-QOwn/linglong.yaml
+++ b/io.github.Regin-QOwn/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.Regin-QOwn
+  name: Regin-QOwn
+  version: 23.9.0
+  kind: app
+  description: |
+    Regin is a plain-text file notepad and todo-list manager with markdown support and Nextcloud / ownCloud integration.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/LycaonIndustries/Regin-QOwn.git
+  commit: 79346721d87c91a04fe60d0e90bac63a8a8ee5c5
+  
+build:
+  kind: qmake
+  manual :
+    configure: |
+      cd src
+      qmake -makefile ${conf_args} ${extra_args}


### PR DESCRIPTION
    Regin is a plain-text file notepad and todo-list manager with markdown support and Nextcloud / ownCloud integration.

Log: add software name--Regin-QOwn
![Regin-QOwn](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b2eeeeac-0654-45bd-91a1-98e64cdce3b7)
