### PR TITLE
build: add kochmorse

### DIFF
--- a/io.github.kochmorse/linglong.yaml
+++ b/io.github.kochmorse/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.kochmorse
+  name: kochmorse
+  version: 3.5.1
+  kind: app
+  description: |
+    A simple morse tutor using the Koch method.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/hmatuschek/kochmorse.git
+  commit: 51b81986d07217441ac0c5623a8181ddd30821f7
+
+build:
+  kind: cmake


### PR DESCRIPTION
    A simple morse tutor using the Koch method.

Log: add software name--kochmorse
![kochmorse](https://github.com/linuxdeepin/linglong-hub/assets/147463620/56fb3ae9-bef6-4f27-85b4-2c7e2ef68756)
