### PR TITLE
build: add countdown

### DIFF
--- a/io.github.countdown/linglong.yaml
+++ b/io.github.countdown/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.countdown
+  name: countdown
+  version: 1.2.2
+  kind: app
+  description: |
+    A simple count-down clock for exams etc.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+ 
+source:
+  kind: git
+  url: https://github.com/hmatuschek/countdown.git
+  commit: 1c80729f7cbe43a5af2438ef74a3bfaa3c952443
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.countdown/patches/0001-install.patch
+++ b/io.github.countdown/patches/0001-install.patch
@@ -1,0 +1,25 @@
+From c43b4323a101490e87d369c212bfa107640c30ec Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 27 Mar 2024 10:53:51 +0800
+Subject: [PATCH] install
+
+---
+ src/countdown.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/countdown.cc b/src/countdown.cc
+index f7581be..9d1c6b5 100644
+--- a/src/countdown.cc
++++ b/src/countdown.cc
+@@ -9,7 +9,7 @@
+ #include <QString>
+ #include <QFontMetrics>
+ #include <QFont>
+-
++#include <QPainterPath>
+ 
+ Countdown::Countdown(Application &app, QWidget *parent)
+   : QWidget(parent), _app(app)
+-- 
+2.33.1
+


### PR DESCRIPTION
    A simple count-down clock for exams etc.

Log: add software name--countdown
![countdown](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7ab2e1d6-fb5b-4888-a112-f344249c33c9)
