### PR TITLE
build: add app inventory-files

### DIFF
--- a/io.github.inventory-files/linglong.yaml
+++ b/io.github.inventory-files/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.inventory-files
+  name: inventory-files
+  version: 0.0.3
+  kind: app
+  description: |
+    Program for inventory files on your computer (for linux).
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/sea-kg/inventory-files.git
+  commit: d81e961535170f8b29e7b8b47eb6176f8e7be095
+  patch:
+    - patches/fix_install.patch
+    - patches/fix_desktop.patch
+
+build:
+  kind: qmake

--- a/io.github.inventory-files/patches/fix_desktop.patch
+++ b/io.github.inventory-files/patches/fix_desktop.patch
@@ -1,0 +1,18 @@
+diff --git a/contrib/ppa/install-files/usr/share/applications/inventory-files.desktop b/contrib/ppa/install-files/usr/share/applications/inventory-files.desktop
+index d0b68c7..6fb33c4 100644
+--- a/contrib/ppa/install-files/usr/share/applications/inventory-files.desktop
++++ b/contrib/ppa/install-files/usr/share/applications/inventory-files.desktop
+@@ -1,10 +1,10 @@
+ [Desktop Entry]
+ Name=Inventory Files
+ Comment=Inventory Files
+-Exec=/usr/bin/inventory-files %U
++Exec=inventory-files %U
+ Icon=inventory-files
+ Terminal=false
+ Type=Application
+ StartupNotify=true
+ Encoding=UTF-8
+-Categories=Application;
+\ No newline at end of file
++Categories=Application;

--- a/io.github.inventory-files/patches/fix_install.patch
+++ b/io.github.inventory-files/patches/fix_install.patch
@@ -1,0 +1,16 @@
+diff --git a/inventory-files.pro b/inventory-files.pro
+index 24bda24..f7bedf8 100644
+--- a/inventory-files.pro
++++ b/inventory-files.pro
+@@ -134,3 +134,11 @@ RESOURCES     = inventory-files.qrc
+ 
+ OBJECTS_DIR = tmp/
+ MOC_DIR = tmp/
++
++target.path = $$PREFIX/bin
++desktop.files = contrib/ppa/install-files/usr/share/applications/inventory-files.desktop
++desktop.path = $$PREFIX/share/applications
++icon.files = contrib/ppa/install-files/usr/share/icons/hicolor
++icon.path = $$PREFIX/share/icons
++
++INSTALLS += target desktop icon


### PR DESCRIPTION
Program for inventory files on your computer (for linux).

先使用 insert 按钮加入一个目录，然后才能使用 scan 按钮检索，然后在 files 页面会有检索的结果。

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/b4e56a88-c380-475c-8b40-fb33212d1507)

Logs: add app name--inventory-files