### PR TITLE
build: add Capturer

### DIFF
--- a/io.github.Capturer/linglong.yaml
+++ b/io.github.Capturer/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.Capturer
+  name: Capturer 
+  version: 1.6.1.0
+  kind: app
+  description: |
+     Capturer是一款主打快速截图、贴图、录屏和录制GIF的软件.使用快捷键可以快速选择感兴趣的桌面区域或窗口进行截图/录制，并将截图快速钉在桌面上.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: cmake/3.28.0
+  - id: lapack/3.8.0.1
+
+source:
+  kind: git
+  url: https://github.com/ffiirree/Capturer.git
+  commit: d884653f161ae580a7ab1cbac3f0fe7f1d39c5cb
+  patch: patches/0001-fix-path.patch
+ 
+build:
+  kind: cmake

--- a/io.github.Capturer/patches/0001-fix-path.patch
+++ b/io.github.Capturer/patches/0001-fix-path.patch
@@ -1,0 +1,43 @@
+From 76ccb230c52a8bf2de5ceeb76ef93961c1a9eeb3 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Fri, 12 Apr 2024 21:48:18 +0800
+Subject: [PATCH] fix-path
+
+---
+ CMakeLists.txt   | 6 +++---
+ capturer.desktop | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f36b7c9..81a0ab0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -160,9 +160,9 @@ elseif (UNIX AND NOT APPLE)
+     # installed: ~/.local/logs/capturer/capturer-*.log
+     install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+     install(FILES ${QM_FILES} DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/capturer/translations")
+-    install(FILES "${PROJECT_SOURCE_DIR}/capturer.desktop" DESTINATION "/usr/share/applications")
+-    install(FILES "${PROJECT_SOURCE_DIR}/src/resources/icons/capturer.png" DESTINATION "/usr/share/pixmaps")
+-    install(FILES "${PROJECT_SOURCE_DIR}/src/resources/icons/capturer.png" DESTINATION "/usr/share/icons/hicolor/128x128/apps")
++    install(FILES "${PROJECT_SOURCE_DIR}/capturer.desktop" DESTINATION "share/applications")
++    install(FILES "${PROJECT_SOURCE_DIR}/src/resources/icons/capturer.png" DESTINATION "share/pixmaps")
++    install(FILES "${PROJECT_SOURCE_DIR}/src/resources/icons/capturer.png" DESTINATION "share/icons")
+ endif ()
+ 
+ add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P "${PROJECT_SOURCE_DIR}/cmake/uninstall.cmake")
+diff --git a/capturer.desktop b/capturer.desktop
+index f3ea73b..f91e537 100644
+--- a/capturer.desktop
++++ b/capturer.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Name=Capturer
+ Comment=Screen recording and screenshot.
+-Exec=/usr/local/bin/capturer
++Exec=capturer
+ Icon=capturer
+ X-GNOME-Autostart-enabled=true
+ Terminal=false
+-- 
+2.33.1
+


### PR DESCRIPTION
Capturer是一款主打快速截图、贴图、录屏和录制GIF的软件.使用快捷键可以快速选择感兴趣的桌面区域或窗口进行截图/录制，并将截图快速钉在桌面上.

log: add a software

