### PR TITLE
build: add libsndfile

### DIFF
--- a/libsndfile/linglong.yaml
+++ b/libsndfile/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: libsndfile
+  name: libsndfile
+  kind: lib
+  version: 1.2.2.1
+  description: |
+    A C library for reading and writing sound files containing sampled audio data.
+base:
+  id: org.deepin.base
+  version: 23.0.0
+
+
+source:
+  kind: git
+  url: https://github.com/libsndfile/libsndfile.git
+  commit: 7ed4773251c26653b5ee1a0815bfe8b213c14b54
+  patch: patches/0001-fix-fpic.patch
+
+build:
+  kind: cmake

--- a/libsndfile/patches/0001-fix-fpic.patch
+++ b/libsndfile/patches/0001-fix-fpic.patch
@@ -1,0 +1,25 @@
+From 3fa38a4c3b6f5319d7ad488fde1482cdae195388 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Sat, 13 Apr 2024 10:25:14 +0800
+Subject: [PATCH] fix-fpic
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c12c68be..e934ac0c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,7 +36,7 @@ if (BUILD_REGTEST)
+ endif ()
+ 
+ project(libsndfile VERSION 1.2.2)
+-
++add_compile_options(-fPIC)
+ #
+ # Variables
+ #
+-- 
+2.33.1
+


### PR DESCRIPTION
A C library for reading and writing sound files containing sampled audio data.

log: recomplie with -fPIC