### PR TITLE
build: add caj2pdf

### DIFF
--- a/io.github.caj2pdf-qt/linglong.yaml
+++ b/io.github.caj2pdf-qt/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.caj2pdf-qt
+  name: caj2pdf-qt
+  version: 0.1.5.1
+  kind: app
+  description: |
+    CAJ 转 PDF 转换器（GUI 版本）
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/sainnhe/caj2pdf-qt.git
+  commit: 5ea291c0f27c28dc533398c4e827215c18e1cceb
+  patch: patches/0001-fix-desktop.patch
+
+build:
+  kind: cmake

--- a/io.github.caj2pdf-qt/patches/0001-fix-desktop.patch
+++ b/io.github.caj2pdf-qt/patches/0001-fix-desktop.patch
@@ -1,0 +1,36 @@
+From 7363c6fda560e39d54ec6a09b1d090d2bebe5792 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Sat, 13 Apr 2024 14:41:26 +0800
+Subject: [PATCH] fix-desktop
+
+---
+ CMakeLists.txt | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1312dd8..f6198f8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,3 +48,18 @@ set_target_properties(
+              MACOSX_BUNDLE_SHORT_VERSION_STRING
+              ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+              MACOSX_BUNDLE_ICON_FILE convert)
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=caj2pdf
++Exec=caj2pdf
++Icon=convert
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/caj2pdf.desktop "${DESKTOP_FILE_CONTENT}")
++
++install(PROGRAMS ${CMAKE_BINARY_DIR}/caj2pdf.desktop DESTINATION share/applications)
++install(PROGRAMS ${PROJECT_SOURCE_DIR}/icons/convert.png DESTINATION share/icons)
++install(TARGETS caj2pdf DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
CAJ 转 PDF 转换器（GUI 版本）

log: add a software
![image](https://github.com/linuxdeepin/linglong-hub/assets/84424520/82c240c8-c72f-4cfa-a590-cbcbe7056dfb)
