### PR TITLE
builf: add mpv

### DIFF
--- a/mpv/linglong.yaml
+++ b/mpv/linglong.yaml
@@ -1,0 +1,29 @@
+package:
+  id: mpv
+  name: mpv
+  version: 0.35.0
+  kind: lib
+  description: |
+     mpv is a free (as in freedom) media player for the command line. It supports a wide variety of media file formats, audio and video codecs, and subtitle types.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+source:
+  kind: git
+  url: https://github.com/mpv-player/mpv.git
+  commit: 75d938912ddd50f5658d874c59e1b50e13b28bf1 
+  patch: patches/0001-fix-install.patch
+depends:
+  - id: meson/1.1.1
+  - id: python/3.10.13.0
+build:
+  kind: manual
+  manual: 
+    configure: |
+      export HOME=${PREFIX}
+      meson setup --prefix ${PREFIX} build
+    build: |
+      meson compile -C build
+    install: |
+      meson install -C build

--- a/mpv/patches/0001-fix-install.patch
+++ b/mpv/patches/0001-fix-install.patch
@@ -1,0 +1,34 @@
+From a1b246f66b0c642680f4cbfb6831871901899643 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Wed, 17 Apr 2024 22:30:00 +0800
+Subject: [PATCH] fix-install
+
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index af4a6bcd97..f314519ef8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1650,7 +1650,7 @@ if win32
+ endif
+ 
+ 
+-if get_option('libmpv')
++if true
+     client_h_define = cc.get_define('MPV_CLIENT_API_VERSION', prefix: '#include "libmpv/client.h"',
+                                     include_directories: include_directories('.'))
+     major = client_h_define.split('|')[0].split('<<')[0].strip('() ')
+@@ -1668,7 +1668,7 @@ if get_option('libmpv')
+     install_headers(headers, subdir: 'mpv')
+ endif
+ 
+-if get_option('cplayer')
++if false
+     datadir = get_option('datadir')
+     confdir = get_option('sysconfdir')
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
mpv is a free (as in freedom) media player for the command line. It supports a wide variety of media file formats, audio and video codecs, and subtitle types.

log: add lib