### PR TITLE
build: add SdPlayer

### DIFF
--- a/io.github.SdPlayer/linglong.yaml
+++ b/io.github.SdPlayer/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.SdPlayer
+  name: SdPlayer
+  version: 2.0.0
+  kind: app
+  description: |
+    Music player for square dance tape groups 
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/dehnert/SdPlayer.git
+  commit: 6604a2ee15445c7ad61e950ff9edecf0d2986dea
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.SdPlayer/patches/0001-install.patch
+++ b/io.github.SdPlayer/patches/0001-install.patch
@@ -1,0 +1,41 @@
+From e2381310246b5b8039e18939351d7a2baf56603b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 8 Apr 2024 14:16:26 +0800
+Subject: [PATCH] install
+
+---
+ SdPlayer.pro                   | 6 ++++++
+ assets/krubow-sdplayer.desktop | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/SdPlayer.pro b/SdPlayer.pro
+index f0d687d..bb92225 100644
+--- a/SdPlayer.pro
++++ b/SdPlayer.pro
+@@ -66,3 +66,9 @@ macx {
+   LIBS += -L"/Applications/VLC.app/Contents/MacOS/lib"
+   LIBS += -lvlc
+ }
++target.path =$$PREFIX/bin
++desktop.files =assets/krubow-sdplayer.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = Music.png
++INSTALLS += target desktop icons
+\ No newline at end of file
+diff --git a/assets/krubow-sdplayer.desktop b/assets/krubow-sdplayer.desktop
+index f89e2e4..7892727 100644
+--- a/assets/krubow-sdplayer.desktop
++++ b/assets/krubow-sdplayer.desktop
+@@ -3,7 +3,7 @@ Encoding=UTF-8
+ Name=SdPlayer
+ Comment=Square Dance music player
+ Exec=SdPlayer
+-Icon=/usr/share/sdplayer/Music.png
++Icon=Music
+ StartupNotify=true
+ Terminal=false
+ Type=Application
+-- 
+2.33.1
+


### PR DESCRIPTION
    Music player for square dance tape groups

Log: add software name--SdPlayer
![SdPlayer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/b2159277-2e85-4116-b843-8ee2ea0d0250)
