### PR TITLE
build: add GitlHEVCAnalyzer

### DIFF
--- a/io.github.GitlHEVCAnalyzer/linglong.yaml
+++ b/io.github.GitlHEVCAnalyzer/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.GitlHEVCAnalyzer
+  name: GitlHEVCAnalyzer
+  version: 1.5.1
+  kind: app
+  description: |
+    Gitl HEVC/H.265 Analyzer based on Qt. Custom filters supported.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/lheric/GitlHEVCAnalyzer.git
+  commit: 6975257b6eeddc356fa91f1fa26ca1beed29ebbe
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp screenshots/logo.png screenshots/Gitl_HEVC_Analyzer.png
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.GitlHEVCAnalyzer/patches/0001-install.patch
+++ b/io.github.GitlHEVCAnalyzer/patches/0001-install.patch
@@ -1,0 +1,45 @@
+From 135b81d3639fdbd1624641a813e988a12612eb32 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 18 Apr 2024 08:55:40 +0800
+Subject: [PATCH] install
+
+---
+ src/GitlHEVCAnalyzer.desktop | 9 +++++++++
+ src/src.pro                  | 7 +++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 src/GitlHEVCAnalyzer.desktop
+
+diff --git a/src/GitlHEVCAnalyzer.desktop b/src/GitlHEVCAnalyzer.desktop
+new file mode 100644
+index 0000000..a8e8cab
+--- /dev/null
++++ b/src/GitlHEVCAnalyzer.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Exec=Gitl_HEVC_Analyzer
++Name=Gitl_HEVC_Analyzer
++Icon=Gitl_HEVC_Analyzer
++StartupNotify=false
++Terminal=false
++Categories=Analyzer;Qt;Utility;
++Type=Application
++Comment=Gitl HEVC/H.265 Analyzer based on Qt. Custom filters supported.
+\ No newline at end of file
+diff --git a/src/src.pro b/src/src.pro
+index 19172c2..4010871 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -206,3 +206,10 @@ RC_FILE = resources/icons/appicon.rc
+ 
+ RESOURCES += \
+     resources/resources.qrc
++
++target.path =$$PREFIX/bin
++desktop.files =GitlHEVCAnalyzer.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../screenshots/Gitl_HEVC_Analyzer.png
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    Gitl HEVC/H.265 Analyzer based on Qt. Custom filters supported.

Log: add software name--GitlHEVCAnalyzer
![GitlHEVCAnalyzer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/3ed3d40f-b103-4699-8ef3-8d23e62d5d1c)
