### PR TITLE
build: add ImGuiFontStudio

### DIFF
--- a/io.github.ImGuiFontStudio/linglong.yaml
+++ b/io.github.ImGuiFontStudio/linglong.yaml
@@ -1,0 +1,27 @@
+package:
+  id: io.github.ImGuiFontStudio
+  name: ImGuiFontStudio 
+  version: 0.8.0
+  kind: app
+  description: |
+     ImGuiFontStudio is a tool for Subset font and extract glyph names for use embbeded or not in a software, especially for use with ImGui for embedded way.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+variables:
+  extra_args: |
+     -DCMAKE_BUILD_TYPE=Release
+
+source:
+  kind: git
+  url: https://github.com/aiekick/ImGuiFontStudio.git
+  commit: 9819f342f7476746db7ac9253372508163ff8e3d
+  patch: 
+    - patches/0001-fix-code.patch
+    - patches/0001-fix-install.patch
+
+
+build:
+  kind: cmake

--- a/io.github.ImGuiFontStudio/patches/0001-fix-code.patch
+++ b/io.github.ImGuiFontStudio/patches/0001-fix-code.patch
@@ -1,0 +1,62 @@
+From 93d226669d82e6fcfdcc8045d5e49fde881d318d Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Sat, 20 Apr 2024 10:39:04 +0800
+Subject: [PATCH] fix-code
+
+---
+ src/Gui/ImWidgets.cpp     | 4 ++--
+ src/Panes/ParamsPane.cpp  | 2 +-
+ src/Project/FontInfos.cpp | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/Gui/ImWidgets.cpp b/src/Gui/ImWidgets.cpp
+index f844d23..74a0e97 100644
+--- a/src/Gui/ImWidgets.cpp
++++ b/src/Gui/ImWidgets.cpp
+@@ -749,7 +749,7 @@ bool ImGui::CheckBoxBoolDefault(const char* vName, bool* vVar, bool vDefault, co
+ 
+ 	if (vHelp)
+ 		if (ImGui::IsItemHovered())
+-			ImGui::SetTooltip(vHelp);
++			ImGui::SetTooltip("%s", vHelp);
+ 
+ 	return change;
+ }
+@@ -1057,7 +1057,7 @@ bool ImGui::ButtonNoFrame(const char* vLabel, ImVec2 size, ImVec4 vColor, const
+ 
+ 	if (vHelp)
+ 		if (ImGui::IsItemHovered())
+-			ImGui::SetTooltip(vHelp);
++			ImGui::SetTooltip("%s", vHelp);
+ 
+ 	return pressed;
+ }
+diff --git a/src/Panes/ParamsPane.cpp b/src/Panes/ParamsPane.cpp
+index 500d078..e66706f 100644
+--- a/src/Panes/ParamsPane.cpp
++++ b/src/Panes/ParamsPane.cpp
+@@ -193,7 +193,7 @@ void ParamsPane::DrawParamsPane()
+ 									if (sw > cw)
+ 									{
+ 										if (ImGui::IsItemHovered())
+-											ImGui::SetTooltip(itFont.first.c_str());
++											ImGui::SetTooltip("%s", itFont.first.c_str());
+ 									}
+ 								}
+ 								if (ImGui::TableSetColumnIndex(1)) // second column
+diff --git a/src/Project/FontInfos.cpp b/src/Project/FontInfos.cpp
+index 7268bfb..95ea56e 100644
+--- a/src/Project/FontInfos.cpp
++++ b/src/Project/FontInfos.cpp
+@@ -438,7 +438,7 @@ void FontInfos::DrawInfos()
+ 								if (sw > aw - ImGui::GetCursorPosX())
+ 								{
+ 									if (ImGui::IsItemHovered())
+-										ImGui::SetTooltip(infos.second.c_str());
++										ImGui::SetTooltip("%s", infos.second.c_str());
+ 								}
+ 							}
+ 						}
+-- 
+2.33.1
+

--- a/io.github.ImGuiFontStudio/patches/0001-fix-install.patch
+++ b/io.github.ImGuiFontStudio/patches/0001-fix-install.patch
@@ -1,0 +1,51 @@
+From 7e491a81cea656a4b5d7c6b93983f280ef3b7ef0 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Sat, 20 Apr 2024 11:03:32 +0800
+Subject: [PATCH] fix-install
+
+---
+ CMakeLists.txt | 26 +++++++++++++++++++-------
+ 1 file changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 59e47c4..bb191e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,15 +136,27 @@ elseif(WIN32)
+ 		set_target_properties(${PROJECT} PROPERTIES	OUTPUT_NAME "${PROJECT}_Msvc_${ARCH}")
+ 	endif()
+ elseif(UNIX)
+-	set_target_properties(${PROJECT} PROPERTIES	OUTPUT_NAME "${PROJECT}_${ARCH}")
++	set_target_properties(${PROJECT} PROPERTIES	OUTPUT_NAME "${PROJECT}")
+ endif()
+ 
+-set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/bin/${ARCH}")
+-install(DIRECTORY projects DESTINATION "${CMAKE_SOURCE_DIR}/bin/${ARCH}")
+-install(DIRECTORY samples_Fonts DESTINATION "${CMAKE_SOURCE_DIR}/bin/${ARCH}")
+-install(DIRECTORY doc DESTINATION "${CMAKE_SOURCE_DIR}/bin/${ARCH}")
+-install(FILES LICENSE MacOSXBundleInfo.plist.in README.md DESTINATION "${CMAKE_SOURCE_DIR}/bin/${ARCH}")
+-install(TARGETS ${PROJECT} DESTINATION ${CMAKE_INSTALL_PREFIX})
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=ImGuiFontStudio
++Exec=ImGuiFontStudio
++Icon=dst_edit
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/ImGuiFontStudio.desktop "${DESKTOP_FILE_CONTENT}")
++set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
++install(DIRECTORY projects DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
++install(DIRECTORY samples_Fonts DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
++install(DIRECTORY doc DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
++install(FILES LICENSE MacOSXBundleInfo.plist.in README.md DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
++install(PROGRAMS ${CMAKE_BINARY_DIR}/ImGuiFontStudio.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
++install(PROGRAMS ${CMAKE_BINARY_DIR}/../doc/dst_edit.png DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons)
++install(TARGETS ${PROJECT} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+ 
+ if (USE_VULKAN)
+ 	set(BACKEND_INCLUDE_DIRS ${Vulkan_INCLUDE_DIRS})
+-- 
+2.33.1
+


### PR DESCRIPTION
ImGuiFontStudio is a tool for Subset font and extract glyph names for use embbeded or not in a software, especially for use with ImGui for embedded way.

log: add software