### PR TITLE
build: add vchar64

### DIFF
--- a/io.github.vchar64/linglong.yaml
+++ b/io.github.vchar64/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.vchar64
+  name: vchar64
+  version: 0.2.4
+  kind: app
+  description: |
+    editor for the Commodore 64
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ricardoquesada/vchar64.git
+  commit: aba4dbb30b9edee241850f7131bc1d724bb8b36a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp src/res/logo512.png src/res/vchar64.png
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.vchar64/patches/0001-install.patch
+++ b/io.github.vchar64/patches/0001-install.patch
@@ -1,0 +1,31 @@
+From 455d0b98eb8936bd7e4f634cf7db54098c0a9b8c Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 19 Apr 2024 21:36:53 +0800
+Subject: [PATCH] install
+
+---
+ src/src.pro | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/src.pro b/src/src.pro
+index b71215a..928613d 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -38,6 +38,14 @@ defineTest(minQtVersion) {
+ TARGET = vchar64
+ target.path = $${PREFIX}/bin
+ INSTALLS += target
++desktop.files =../moe.retro.vchar64.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = res/vchar64.png
++
++INSTALLS +=desktop icons
++
++
+ win32 {
+     DESTDIR = ..
+ } else {
+-- 
+2.33.1
+


### PR DESCRIPTION
    editor for the Commodore 64

Log: add software name--vchar64
![vchar64](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a4261b21-98fa-45ae-bc6a-0fce58a12433)
