### PR TITLE
build: add helloworld-gui

### DIFF
--- a/io.github.helloworld-gui/linglong.yaml
+++ b/io.github.helloworld-gui/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.helloworld-gui
+  name: helloworld-gui
+  version: 1.5.0
+  kind: app
+  description: |
+    Cross-platform GUI version of Hello World. This is useful for checking the operation of the GUI.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/enjoysoftware/helloworld-gui.git
+  commit: 7e8cd9eaf06c3b2dbfbc95c93f234c61dbc83947
+
+build:
+  kind: qmake
+ 

--- a/io.github.helloworld-gui/patches/0001-install.patch
+++ b/io.github.helloworld-gui/patches/0001-install.patch
@@ -1,0 +1,22 @@
+From 04c786fa3180635e8da4009638c6fbfe18b821a5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 20 Apr 2024 20:32:51 +0800
+Subject: [PATCH] install
+
+---
+ src/cdcat.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cdcat.pro b/src/cdcat.pro
+index 4045577..ec4c411 100644
+--- a/src/cdcat.pro
++++ b/src/cdcat.pro
+@@ -1,4 +1,4 @@
+-lessThan(QT_VERSION, 5.2.0): error(This project requires Qt 5.2.0 or later)
++
+ 
+ TRANSLATIONS = lang/cdcat_hu.ts \
+                lang/cdcat_de.ts \
+-- 
+2.33.1
+


### PR DESCRIPTION
    Cross-platform GUI version of Hello World. This is useful for checking the operation of the GUI.

Log: add software name--helloworld-gui
![helloworld-gui](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a8612c11-3f8a-4a8c-b96c-df91a8be71c8)
