### PR TITLE
build: add sfl-library

### DIFF
--- a/sfl-library/linglong.yaml
+++ b/sfl-library/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: sfl-library
+  name: sfl-library
+  version: 1.4.0
+  kind: lib
+  description: |
+    C++11 header-only library. Small vector. Small flat map/set/multimap/multiset (ordered and unordered). Compact vector. Segmented vector.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/slavenf/sfl-library.git
+  commit: ad877c8659159fbbb9d9b228af5ae31ee600e1bd
+
+build:
+  kind: cmake


### PR DESCRIPTION
C++11 header-only library. Small vector. Small flat map/set/multimap/multiset (ordered and unordered). Compact vector. Segmented vector.

log: add lib