### PR TITLE
build: add SerialTest

### DIFF
--- a/io.github.SerialTest/linglong.yaml
+++ b/io.github.SerialTest/linglong.yaml
@@ -1,0 +1,34 @@
+package:
+  id: io.github.SerialTest
+  name: SerialTest
+  version: 0.3.5
+  kind: app
+  description: |
+    A versatile test tool running on Windows/Linux/macOS/Android.Works as data transceiver/realtime plotter/shortcut/file transceiver.Supports serial port, Bluetooth SPP client/server, Bluetooth LE client, TCP client/server, UDP.
+
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/wh201906/SerialTest.git
+  commit: 37bc8dadf9166b2c9a64737139ed1cc222779c14
+  patch: patches/0001-fix-desktop.patch
+
+depends:
+  - id: qtserialport/5.15.7
+  - id: qtconnectivity/5.15.7
+    type: runtime
+  - id: QCustomPlot/2.1.1.1
+build:
+  kind: qmake
+  manual :
+    configure: |
+      cd src
+      qmake SerialTest.pro ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.SerialTest/patches/0001-fix-desktop.patch
+++ b/io.github.SerialTest/patches/0001-fix-desktop.patch
@@ -1,0 +1,47 @@
+From 27c6932ecc2815209ca1b07dbbe29358bdc5b8ee Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Mon, 22 Apr 2024 20:23:17 +0800
+Subject: [PATCH] fix-desktop
+
+---
+ src/SerialTest.desktop | 9 +++++++++
+ src/SerialTest.pro     | 7 +++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 src/SerialTest.desktop
+
+diff --git a/src/SerialTest.desktop b/src/SerialTest.desktop
+new file mode 100644
+index 0000000..75e3585
+--- /dev/null
++++ b/src/SerialTest.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Categories=Tool;Qt;
++Exec=SerialTest
++Name=SerialTest
++Icon=SerialTest_nobg
++StartupNotify=false
++Terminal=false
++Type=Application
++X-Deepin-Vendor=user-custom
+diff --git a/src/SerialTest.pro b/src/SerialTest.pro
+index afdc9e1..a5d6363 100644
+--- a/src/SerialTest.pro
++++ b/src/SerialTest.pro
+@@ -102,6 +102,13 @@ qnx {
+     message(Install path: $${target.path})
+ }
+ 
++DATADIR = $$PREFIX/share
++desktop.files = SerialTest.desktop
++desktop.path = $$DATADIR/applications/
++icon.files = icon/raw/SerialTest_nobg.png
++icon.path= $$DATADIR/icons/
++INSTALLS += desktop icon
++
+ # Remember to change version in AndroidManifest.xml
+ VERSION = 0.3.5
+ QMAKE_TARGET_PRODUCT = "SerialTest"
+-- 
+2.33.1
+


### PR DESCRIPTION
A versatile test tool running on Windows/Linux/macOS/Android.Works as data transceiver/realtime plotter/shortcut/file transceiver.Supports serial port, Bluetooth SPP client/server, Bluetooth LE client, TCP client/server, UDP.

log: add SerialTest