### PR TITLE
build: add uDevkit-IDE

### DIFF
--- a/io.github.uDevkit-IDE/linglong.yaml
+++ b/io.github.uDevkit-IDE/linglong.yaml
@@ -1,0 +1,30 @@
+package:
+  id: io.github.uDevkit-IDE
+  name: uDevkit-IDE
+  version: 1.0.0
+  kind: app
+  description: |
+    An IDE for uDevkit or C/C++ projects with Git written in Qt5
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/UniSwarm/uDevkit-IDE.git
+  commit: 576c2166d23da47043f47b25089ef19314b29fb6
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp src/udk-ide.ico src/udk-ide.png
+      rm contrib/edbee-data/syntaxfiles/'Rd (R Documentation).tmLanguage'
+      cd src
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.uDevkit-IDE/patches/0001-install.patch
+++ b/io.github.uDevkit-IDE/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 6710eca553d8964d6b56d085a6fe6779d43fd7e4 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 24 Apr 2024 09:59:33 +0800
+Subject: [PATCH] install
+
+---
+ src/udk-ide.desktop.in | 2 +-
+ src/udk-ide.pro        | 6 +-----
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/src/udk-ide.desktop.in b/src/udk-ide.desktop.in
+index 9ccb8f3..9369b30 100644
+--- a/src/udk-ide.desktop.in
++++ b/src/udk-ide.desktop.in
+@@ -3,5 +3,5 @@ Type=Application
+ Name=uDevkit-IDE
+ Comment=UniSwarm IDE
+ Exec=$$target.path/udk-ide
+-Icon=$$icons.path/udk-ide.ico
++Icon=$$icons.path/udk-ide
+ Categories=IDE;
+diff --git a/src/udk-ide.pro b/src/udk-ide.pro
+index 3cb7408..6f62e72 100644
+--- a/src/udk-ide.pro
++++ b/src/udk-ide.pro
+@@ -139,10 +139,6 @@ win32|win64
+     RC_FILE = udk-ide.rc
+ }
+ 
+-isEmpty(PREFIX)
+-{
+-    PREFIX=/usr/local
+-}
+ target.path=$$PREFIX/bin
+ unix
+ {
+@@ -151,7 +147,7 @@ unix
+     desktop.files = udk-ide.desktop
+     INSTALLS += desktop
+     icons.path  = $$PREFIX/share/icons
+-    icons.files = udk-ide.ico
++    icons.files = udk-ide.png
+     INSTALLS += icons
+     data.path  = $$PREFIX/data
+     data.files = ../data/*
+-- 
+2.33.1
+


### PR DESCRIPTION
    An IDE for uDevkit or C/C++ projects with Git written in Qt5

Log: add software name--uDevkit-IDE
![uDevkit](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7f078eeb-32a8-4640-b1f0-251a3f8c0870)
