### PR TITLE
build: add ClownMapEd

### DIFF
--- a/io.github.ClownMapEd/linglong.yaml
+++ b/io.github.ClownMapEd/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.ClownMapEd
+  name: ClownMapEd
+  version: 1.1.2
+  kind: app
+  description: |
+    Sonic the Hedgehog sprite editor, portable clone of Xenowhirl's SonMapEd.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/Clownacy/ClownMapEd.git
+  commit: 71626887ddad0e0f990fad08c858fd6b9de426c5
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Sonic the Hedgehog sprite editor, portable clone of Xenowhirl's SonMapEd.

Log: add software name--ClownMapEd
![ClownMapEd](https://github.com/linuxdeepin/linglong-hub/assets/147463620/64e4e30e-0582-4bb0-9fc1-99c5059d3ce9)
