### PR TITLE
build: add qactus

### DIFF
--- a/io.github.qactus/linglong.yaml
+++ b/io.github.qactus/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.qactus
+  name: qactus
+  version: 2.0.3
+  kind: app
+  description: |
+    A Qt-based Open Build Service client
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtkeychain/0.14.0
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/javierllorente/qactus.git
+  commit: f8b6f20706fa0573917f788a3815db3d4a89d72a
+
+build:
+  kind: cmake


### PR DESCRIPTION
    A Qt-based Open Build Service client

Log: add software name--qactus
![qactus](https://github.com/linuxdeepin/linglong-hub/assets/147463620/55605619-7246-41b1-ad52-6495ee8996d9)
