### PR TITLE
build: add QLogo

### DIFF
--- a/io.github.QLogo/linglong.yaml
+++ b/io.github.QLogo/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.QLogo
+  name: QLogo
+  version: 0.92.0
+  kind: app
+  description: |
+    QLogo is a rewrite of the UCBLogo language and user interface with UCB compatibility.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/jasonsikes/QLogo.git
+  commit: 2703097b9806af92610175d3d8a2e0c52fb63d7c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp icon.ico QLogo.png
+      qmake QLogo.pro  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.QLogo/patches/0001-install.patch
+++ b/io.github.QLogo/patches/0001-install.patch
@@ -1,0 +1,46 @@
+From 49754900a8e632e8630b8e87696ef4c6943e3a6b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 25 Apr 2024 17:32:24 +0800
+Subject: [PATCH] install
+
+---
+ QLogo.desktop | 9 +++++++++
+ QLogo.pro     | 8 ++++++++
+ 2 files changed, 17 insertions(+)
+ create mode 100644 QLogo.desktop
+
+diff --git a/QLogo.desktop b/QLogo.desktop
+new file mode 100644
+index 0000000..2a0a06e
+--- /dev/null
++++ b/QLogo.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Type=Application
++Name=QLogo
++GenericName=UCBLogo Programming Environment
++Exec=QLogo
++Icon=QLogo
++Comment=A UCBLogo-compatible interpreter using Qt and OpenGL
++Categories=Development;IDE;
++Keywords=logo;qlogo;turtle;ucblogo;
+\ No newline at end of file
+diff --git a/QLogo.pro b/QLogo.pro
+index cf40b61..9483c2e 100644
+--- a/QLogo.pro
++++ b/QLogo.pro
+@@ -110,3 +110,11 @@ win32 {
+ # CONFIG += console
+ CONFIG += c++11
+ 
++
++target.path =$$PREFIX/bin
++desktop.files =QLogo.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = QLogo.png
++
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    QLogo is a rewrite of the UCBLogo language and user interface with UCB compatibility.

Log: add software name--QLogo
![QLogo](https://github.com/linuxdeepin/linglong-hub/assets/147463620/6b9dc6f6-8b40-4444-890f-0f6694c888be)
