### PR TITLE
build: add neonbtl-qt

### DIFF
--- a/io.github.neonbtl-qt/linglong.yaml
+++ b/io.github.neonbtl-qt/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.neonbtl-qt
+  name: neonbtl-qt
+  version: 0.38.0
+  kind: app
+  description: |
+    Emulator for Soyuz-Neon PK-11/16
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/nzeemin/neonbtl-qt.git
+  commit: 3f0349151e6600475388afdcad7d3c6b13fae10a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd emulator
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.neonbtl-qt/patches/0001-install.patch
+++ b/io.github.neonbtl-qt/patches/0001-install.patch
@@ -1,0 +1,29 @@
+From fd89d3f74c4eb6248a30874a4a5da24997b45346 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 25 Apr 2024 18:03:48 +0800
+Subject: [PATCH] install
+
+---
+ emulator/QtNeonBtl.pro | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/emulator/QtNeonBtl.pro b/emulator/QtNeonBtl.pro
+index f310df7..9c644a7 100644
+--- a/emulator/QtNeonBtl.pro
++++ b/emulator/QtNeonBtl.pro
+@@ -50,3 +50,12 @@ DEFINES -= UNICODE _UNICODE
+ TRANSLATIONS = neonbtl_en.ts neonbtl_ru.ts
+ CONFIG += c++11
+ QMAKE_CXXFLAGS += -std=c++11
++
++
++target.path =$$PREFIX/bin
++desktop.files =../linux/qtneonbtl.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons
++icons.files = ../linux/qtneonbtl.png
++
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    Emulator for Soyuz-Neon PK-11/16

Log: add software name--neonbtl-qt
![neonbtl-qt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/80e8bbe9-3ec8-4e34-b2b8-ba692f3b9f35)
