### PR TITLE
build: add app NatronPluginManager

### DIFF
--- a/io.github.NatronPluginManager/linglong.yaml
+++ b/io.github.NatronPluginManager/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.NatronPluginManager
+  name: NatronPluginManager
+  version: 1.0.0.3
+  kind: app
+  description: |
+    Natron Plug-in Manager.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: libzip/1.5.1.8
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/rodlie/NatronPluginManager.git
+  commit: 2eb8c8c95cb8bf5a73802201b927fb7c745444f0
+    
+build:
+  kind: cmake


### PR DESCRIPTION
Natron Plug-in Manager.

需要等待插件元文件的下载。
![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/6291c563-7670-4ef0-861a-aca9bf4e2bc2)

Logs: add app name--NatronPluginManager