### PR TITLE
build: add vk-layer-flimes-gui

### DIFF
--- a/io.github.vk-layer-flimes-gui/linglong.yaml
+++ b/io.github.vk-layer-flimes-gui/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.vk-layer-flimes-gui
+  name: vk-layer-flimes-gui
+  version: 1.5.3
+  kind: app
+  description: |
+    GUI for vk-layer-flimes external control
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/zaps166/vk-layer-flimes-gui.git
+  commit: 4e0b6c6d79134232be9ceff8b570f6f224876b51
+
+build:
+  kind: cmake
+  


### PR DESCRIPTION
    GUI for vk-layer-flimes external control

Log: add software name--vk-layer-flimes-gui
![vk-layer-flimes-gui](https://github.com/linuxdeepin/linglong-hub/assets/147463620/a0b08ff1-d28d-4bd8-852b-6ea0759f0200)
