### PR TITLE
build: add KVIrc

### DIFF
--- a/io.github.KVIrc/linglong.yaml
+++ b/io.github.KVIrc/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.KVIrc
+  name: KVIrc
+  version: 5.2.2
+  kind: app
+  description: |
+    The KVIrc IRC Client
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+variables:
+  extra_args: 
+    -DWANT_QTWEBKIT=OFF
+    -DWANT_PERL=OFF
+
+source:
+  kind: git
+  url: https://github.com/kvirc/KVIrc.git
+  commit: c2ae7a4d274623e2f63108f04b1e74f9f88f4ca6
+
+build:
+  kind: cmake


### PR DESCRIPTION
    The KVIrc IRC Client

Log: add software name--KVIrc
![KVIrc](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9bdc059f-4c56-4998-8245-6d90d6f13d63)
