### PR TITLE
build: add app qcheckers

### DIFF
--- a/io.github.qcheckers/linglong.yaml
+++ b/io.github.qcheckers/linglong.yaml
@@ -1,0 +1,21 @@
+package:
+  id: io.github.qcheckers
+  name: QCheckers
+  version: 0.9.1.0
+  kind: app
+  description: |
+    QCheckers (formely known as KCheckers) is a Qt-based checkers board game. It can play english draughts and russian draughts..
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/portnov/qcheckers.git"
+  commit: 8b8a3e64520e8e074e6035e3a12ff3f7075c7463
+  patch: 
+    - patches/fix-icon.patch
+    - patches/fix-install.patch
+
+build:
+  kind: qmake

--- a/io.github.qcheckers/patches/fix-icon.patch
+++ b/io.github.qcheckers/patches/fix-icon.patch
@@ -1,0 +1,10 @@
+diff --git a/qcheckers.desktop b/qcheckers.desktop
+index 925d31e..e144ef4 100644
+--- a/qcheckers.desktop
++++ b/qcheckers.desktop
+@@ -5,4 +5,4 @@ Name=QCheckers
+ GenericName=Checkers board game
+ Type=Application
+ Exec=qcheckers
+-Icon=qcheckers.svg
++Icon=qcheckers

--- a/io.github.qcheckers/patches/fix-install.patch
+++ b/io.github.qcheckers/patches/fix-install.patch
@@ -1,0 +1,12 @@
+diff --git a/src/src.pro b/src/src.pro
+index df72aae..8858f5d 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -47,6 +47,6 @@ desktop.files += ../qcheckers.desktop
+ INSTALLS += desktop
+ 
+ # Install icon
+-icon.path += $$PREFIX/share/icons/hicolor/scalable/apps
++icon.path += $$PREFIX/share/icons/hicolor/scalable/apps
+ icon.files += ../qcheckers.svg
+ INSTALLS += icon


### PR DESCRIPTION
QCheckers is a Qt-based checkers board game.

Log: add app QCheckers

![截图_选择区域_20240503133145](https://github.com/linuxdeepin/linglong-hub/assets/101699371/cfd3d311-4fc2-4c79-84a8-3a3de8736c51)
