### PR TITLE
build: add lib Fast_float

### DIFF
--- a/fastfloat/linglong.yaml
+++ b/fastfloat/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: fast_float
+  name: fast_float
+  version: 6.1.1
+  kind: lib
+  description: |
+    Fast and exact implementation of the C++ from_chars functions for number types: 4x to 10x faster than strtod, part of GCC 12 and WebKit/Safari
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/fastfloat/fast_float.git
+  commit: 1fc3ac3932220b5effaca7203bb1bb771528d256
+
+build:
+  kind: cmake


### PR DESCRIPTION
Fast and exact implementation of the C++ from_chars functions for number types: 4x to 10x faster than strtod, part of GCC 12 and WebKit/Safari

log: add lib