### PR TITLE
build: add app LightCombatManager

### DIFF
--- a/io.github.LightCombatManager/linglong.yaml
+++ b/io.github.LightCombatManager/linglong.yaml
@@ -1,0 +1,18 @@
+package:
+  id: io.github.LightCombatManager
+  name: LightCombatManager
+  version: 2.0.1.1
+  kind: app
+  description: |
+    A small, lightweight cross-platform combat manager for d20-based role-playing games, based on Qt.
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/MaxFleur/LightCombatManager.git
+  commit: eb8db0bbf5fcc0a016cb2516e992699ab8e2142a
+  patch: patches/0001-fix.patch
+build:
+  kind: cmake

--- a/io.github.LightCombatManager/patches/0001-fix.patch
+++ b/io.github.LightCombatManager/patches/0001-fix.patch
@@ -1,0 +1,54 @@
+From 147195d9d533206b385f58591329f60a49a7e7d7 Mon Sep 17 00:00:00 2001
+From: van <751890223@qq.com>
+Date: Thu, 9 May 2024 10:37:20 +0800
+Subject: [PATCH] fix
+
+---
+ CMakeLists.txt | 24 +++++++++++++++++++-----
+ 1 file changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ebaff16..b947367 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,13 +18,13 @@ else()
+     find_package(Qt5 COMPONENTS Widgets REQUIRED)
+ endif()
+ 
+-include(CTest)
+-enable_testing()
+-add_custom_target(checks COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
+-add_dependencies(checks tests)
++#include(CTest)
++#enable_testing()
++#add_custom_target(checks COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
++#add_dependencies(checks tests)
+ 
+ add_subdirectory(src)
+-add_subdirectory(test)
++#add_subdirectory(test)
+ 
+ if(MSVC)
+   target_compile_options(LightCombatManager PRIVATE /W4 /WX)
+@@ -40,3 +40,17 @@ configure_file(
+     IMMEDIATE @ONLY)
+ 
+ add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
++
++set(DESKTOP_FILE_CONTENT "
++[Desktop Entry]
++Type=Application
++Name=LightCombatManager
++Exec=LightCombatManager
++Icon=main_light
++Categories=Utility;
++")
++
++file(WRITE ${CMAKE_BINARY_DIR}/LightCombatManager.desktop "${DESKTOP_FILE_CONTENT}")
++install(PROGRAMS ${CMAKE_BINARY_DIR}/LightCombatManager.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
++install(PROGRAMS ${CMAKE_BINARY_DIR}/../resources/icons/logos/main_light.svg DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)
++install(TARGETS LightCombatManager DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
A small, lightweight cross-platform combat manager for d20-based role-playing games, based on Qt.

log: add app