### PR TITLE
build: add app qputty-qt5

### DIFF
--- a/io.github.qputty/linglong.yaml
+++ b/io.github.qputty/linglong.yaml
@@ -1,0 +1,31 @@
+package:
+  id: io.github.qputty
+  name: qputty
+  version: 0.506.2
+  kind: app
+  description: |
+    A Qt 5 port for putty, the free telnet/ssh client.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+depends:
+  - id: libgssglue
+    version: 0.9.2
+source:
+  kind: git
+  url: "https://github.com/mhc2910463910/qputty-qt.git"
+  commit: 49535366e85c155d491d79940517d3f754b152d9
+  patch: 
+    - patches/fix-install.patch
+    - patches/fix-putty.patch
+    - patches/fix-icon.patch
+build:
+  kind: manual
+  manual: 
+    configure: |
+      qmake PREFIX=${PREFIX} LIB_INSTALL_DIR=${PREFIX}/lib/${TRIPLET}
+    build: |
+      make -j${JOBS}
+    install: |
+      make -j${JOBS} DESTDIR=${dest_dir} install

--- a/io.github.qputty/patches/fix-icon.patch
+++ b/io.github.qputty/patches/fix-icon.patch
@@ -1,0 +1,13 @@
+diff --git a/qPutty.desktop b/qPutty.desktop
+index 7016e06..19726bc 100644
+--- a/qPutty.desktop
++++ b/qPutty.desktop
+@@ -3,7 +3,7 @@ Name=QPutty
+ GenericName=SSH and telnet client
+ Comment=Log on to remote systems using SSH, Telnet or Rlogin
+ Exec=qPutty
+-Icon=qputty
++Icon=putty-32
+ Terminal=false
+ Type=Application
+ StartupNotify=false

--- a/io.github.qputty/patches/fix-install.patch
+++ b/io.github.qputty/patches/fix-install.patch
@@ -1,0 +1,31 @@
+diff --git a/qPutty.pro b/qPutty.pro
+index 31c7217..15526cb 100644
+--- a/qPutty.pro
++++ b/qPutty.pro
+@@ -21,17 +21,22 @@ CONFIG(release,debug|release) {
+ 
+ SOURCES *= putty.cpp
+ 
+-isEmpty(PREFIX){
+-    PREFIX=/usr/local
+-}
++# isEmpty(PREFIX){
++#    PREFIX=/usr/local
++# }
+ 
+ unix {
++    icons.files += putty-32.png
++    icons.path = $$PREFIX/share/icons/hicolor/32x32/apps
++
+     desktopEntry.path = $$PREFIX/share/applications/
+     desktopEntry.files = qPutty.desktop
+ 
+     target.path = $$PREFIX/bin
+     QT+=x11extras
+-    INSTALLS+=target desktopEntry
++    INSTALLS+=target desktopEntry icons
++
++    PKGCONFIG += libgssglue
+ }
+ 
+ macx {

--- a/io.github.qputty/patches/fix-putty.patch
+++ b/io.github.qputty/patches/fix-putty.patch
@@ -1,0 +1,13 @@
+diff --git a/uxputty.c b/uxputty.c
+index 27f33f1..b5d061d 100644
+--- a/uxputty.c
++++ b/uxputty.c
+@@ -39,7 +39,7 @@
+  * Stubs to avoid uxpty.c needing to be linked in.
+  */
+ const int use_pty_argv = FALSE;
+-char **pty_argv;		       /* never used */
++//char **pty_argv;		       /* never used */
+ 
+ /*
+  * Clean up and exit.


### PR DESCRIPTION
A qt 5 port for putty, the free telnet/ssh client

Log: add app qputty-qt5

![image](https://github.com/linuxdeepin/linglong-hub/assets/101699371/c645e248-a2f5-4477-9846-482f91b80305)
