### PR TITLE
build: add exo

### DIFF
--- a/io.github.exo/linglong.yaml
+++ b/io.github.exo/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.exo
+  name: exo
+  version: 0.9.0
+  kind: app
+  description: |
+    Qt GUI, MPRIS interface and a scrobbler for MOC console player / Cmus
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+  
+source:
+  kind: git
+  url: https://github.com/loimu/exo.git
+  commit: d429f9ef0d91a2cf3e6071764fa8664b9eea0712
+
+variables:
+  extra_args: 
+    -DBUILD_LASTFM=OFF
+    -DBUILD_DBUS=OFF
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Qt GUI, MPRIS interface and a scrobbler for MOC console player / Cmus

Log: add software name--exo
![exo](https://github.com/linuxdeepin/linglong-hub/assets/147463620/866b7b81-906f-4926-8e4f-a41d1e380ac7)
