### PR TITLE
build: add bpmdetect

### DIFF
--- a/io.github.bpmdetect/linglong.yaml
+++ b/io.github.bpmdetect/linglong.yaml
@@ -1,0 +1,26 @@
+package:
+  id: io.github.bpmdetect
+  name: bpmdetect
+  version: 0.7.2.1
+  kind: app
+  description: |
+    BPMDetect is automatic BPM (beats per minute) detection utility.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: portaudio19
+    version: 19.6.0
+    type: runtime
+  - id: taglib/1.12.0
+
+source:
+  kind: git
+  url: https://github.com/Tatsh/bpmdetect.git
+  commit: 5bb55a000a447327d22f8521c69521e5728a8fa8
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.bpmdetect/patches/0001-install.patch
+++ b/io.github.bpmdetect/patches/0001-install.patch
@@ -1,0 +1,30 @@
+From a635ff572585466a11852c5eb17d339c5c82a4bc Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sun, 12 May 2024 11:53:59 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ba689f..0cd6dc1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,3 +16,13 @@ pkg_check_modules(VORBIS vorbisfile)
+ 
+ set(CMAKE_AUTOUIC ON)
+ add_subdirectory(src)
++
++install(TARGETS ${PROJECT_NAME}
++             DESTINATION bin)
++
++install(FILES src/bpmdetect-icon.png
++        DESTINATION share/icons/hicolor/16X16/apps/)
++
++
++install(FILES src/bpmdetect.desktop
++            DESTINATION share/applications)
+-- 
+2.33.1
+


### PR DESCRIPTION
    BPMDetect is automatic BPM (beats per minute) detection utility.

Log: add software name--bpmdetect
![bpmdetect](https://github.com/linuxdeepin/linglong-hub/assets/147463620/4d407963-a67d-419c-b2c7-c313a31ba253)
