### PR TITLE
build: add kronos

### DIFF
--- a/io.github.kronos/linglong.yaml
+++ b/io.github.kronos/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.kronos
+  name: kronos
+  version: 1.0.2
+  kind: app
+  description: |
+    Kronos is a desktop application for logging time in Jira
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/llob/kronos.git
+  commit: 6f6ab1cc29c369455f806a00e00b5c7baf4b27f7
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.kronos/patches/0001-install.patch
+++ b/io.github.kronos/patches/0001-install.patch
@@ -1,0 +1,51 @@
+From 797142f7a9447c7f59fc1a0325d48ac760f03410 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Mon, 13 May 2024 10:53:13 +0800
+Subject: [PATCH] install
+
+---
+ kronos.pro                  | 10 +++++++++-
+ packages/deb/kronos.desktop |  4 ++--
+ 2 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/kronos.pro b/kronos.pro
+index f8f141e..d88c1da 100644
+--- a/kronos.pro
++++ b/kronos.pro
+@@ -37,9 +37,17 @@ FORMS += \
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
++target.path =$$PREFIX/bin
++desktop.files =packages/deb/kronos.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = resources/logo/favicon.png
++
++INSTALLS += target desktop icons
++
+ include(kronos.pri)
+ 
+ RESOURCES += \
+diff --git a/packages/deb/kronos.desktop b/packages/deb/kronos.desktop
+index 8124c1d..74ef235 100644
+--- a/packages/deb/kronos.desktop
++++ b/packages/deb/kronos.desktop
+@@ -3,6 +3,6 @@ Encoding=UTF-8
+ Version=1.0
+ Type=Application
+ Terminal=false
+-Exec=/opt/kronos/bin/kronos
++Exec=kronos
+ Name=Kronos
+-Icon=/opt/kronos/resources/logo.png
+\ No newline at end of file
++Icon=favicon
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Kronos is a desktop application for logging time in Jira

Log: add software name--kronos
![kronos](https://github.com/linuxdeepin/linglong-hub/assets/147463620/5d3f300b-01fd-4f91-8f23-dc520ff8c719)
