### PR TITLE
build: add fritzing-app

### DIFF
--- a/io.github.fritzing-app/linglong.yaml
+++ b/io.github.fritzing-app/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.fritzing-app
+  name: fritzing-app
+  version: 0.9.1
+  kind: app
+  description: |
+    The Fritzing application is an Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/fritzing/fritzing-app.git
+  commit: 2cae29006d3311381dae20fb55f1e1478f75be89
+
+build:
+  kind: qmake


### PR DESCRIPTION
    The Fritzing application is an Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists.

Log: add software name--fritzing-app
![fritzing-app](https://github.com/linuxdeepin/linglong-hub/assets/147463620/0b61e67d-338b-43dd-bdf7-bc482cab980c)
