### PR TITLE
build: add app qcad

### DIFF
--- a/io.github.qcad/linglong.yaml
+++ b/io.github.qcad/linglong.yaml
@@ -1,0 +1,22 @@
+package:
+  id: io.github.qcad
+  name: qcad
+  version: 3.29.6.7
+  kind: app
+  description: |
+    QCAD Community Edition 是一个计算机辅助设计应用 (CAD)。.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: "https://github.com/qcad/qcad.git"
+  commit: 38a3944de996268087dc0c51f007109c0a7cb2b6
+  patch: 
+    - patches/fix-3rdparty.patch
+    - patches/fix-install.patch
+    - patches/fix-desktop.patch
+build:
+  kind: qmake

--- a/io.github.qcad/patches/fix-3rdparty.patch
+++ b/io.github.qcad/patches/fix-3rdparty.patch
@@ -1,0 +1,17 @@
+diff --git a/src/3rdparty/3rdparty.pro b/src/3rdparty/3rdparty.pro
+index 55e5271680..3205be912f 100644
+--- a/src/3rdparty/3rdparty.pro
++++ b/src/3rdparty/3rdparty.pro
+@@ -19,8 +19,10 @@ else {
+ }
+ 
+ !r_mobile {
+-    exists(qt-labs-qtscriptgenerator-$${QT_VERSION}) {
+-        SUBDIRS += qt-labs-qtscriptgenerator-$${QT_VERSION}
++#    exists(qt-labs-qtscriptgenerator-$${QT_VERSION}) {
++#        SUBDIRS += qt-labs-qtscriptgenerator-$${QT_VERSION}
++    exists(qt-labs-qtscriptgenerator-5.15.8) {
++        SUBDIRS += qt-labs-qtscriptgenerator-5.15.8
+     }
+     else {
+         lessThan(QT_MAJOR_VERSION, 6) {

--- a/io.github.qcad/patches/fix-desktop.patch
+++ b/io.github.qcad/patches/fix-desktop.patch
@@ -1,0 +1,13 @@
+diff --git a/qcad.desktop b/qcad.desktop
+index 93c5e97201..2d0e6bf32a 100644
+--- a/qcad.desktop
++++ b/qcad.desktop
+@@ -48,7 +48,7 @@ Comment[sv]=2D CAD-system
+ Comment[sl]=Sistem 2D CAD
+ Comment[uk]=2D САПР
+ Comment[tr]=2D CAD Sistemi
+-Exec=qcad %F
++Exec=qcad-bin %F
+ X-MultipleArgs=true
+ Icon=qcad_icon
+ Terminal=false

--- a/io.github.qcad/patches/fix-install.patch
+++ b/io.github.qcad/patches/fix-install.patch
@@ -1,0 +1,20 @@
+diff --git a/qcad.pro b/qcad.pro
+index 74f874ef9d..65d8958023 100644
+--- a/qcad.pro
++++ b/qcad.pro
+@@ -26,3 +26,14 @@ else {
+ dummy {
+     SUBDIRS += scripts
+ }
++releasefile.target = install
++releasefile.commands = mkdir -p $$PREFIX/bin && cp -r $$PWD/release/* $$PREFIX/bin && mkdir -p $$PREFIX/bin/plugins && cp -r $$PWD/plugins/* $$PREFIX/bin/plugins
++QMAKE_EXTRA_TARGETS += releasefile
++
++desktopfile.files += $$PWD/qcad.desktop
++desktopfile.path = $$PREFIX/share/applications
++INSTALLS += desktopfile
++
++iconfile.files += $$PWD/scripts/qcad_icon.svg
++iconfile.path = $$PREFIX/share/icons/hicolor/scalable/apps
++INSTALLS += iconfile
+\ No newline at end of file


### PR DESCRIPTION
QCAD Community Edition 是一个计算机辅助设计应用 (CAD)。

Log: add app qcad

![截图_选择区域_20240515201413](https://github.com/linuxdeepin/linglong-hub/assets/101699371/27f651f6-c86c-482e-bef5-1fe8c2640e04)
