### PR TITLE
build: add posterazor

### DIFF
--- a/io.github.posterazor/linglong.yaml
+++ b/io.github.posterazor/linglong.yaml
@@ -1,0 +1,28 @@
+package:
+  id: io.github.posterazor
+  name: posterazor
+  version: 1.0.1
+  kind: app
+  description: |
+    The PosteRazor cuts a raster image into pieces which can afterwards be printed out and assembled to a poster.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/aportale/posterazor.git
+  commit: 53661c3b09c0fd07c393bf43df2890e4d041b5d6
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cd src
+      qmake -makefile posterazor.pro  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.posterazor/patches/0001-install.patch
+++ b/io.github.posterazor/patches/0001-install.patch
@@ -1,0 +1,48 @@
+From 1119ec3dfb973a6ca36135fbfebbdf0b62a6ce8f Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 15 May 2024 12:02:41 +0800
+Subject: [PATCH] install
+
+---
+ src/PosteRazor.desktop | 10 ++++++++++
+ src/posterazor.pro     |  8 ++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 src/PosteRazor.desktop
+
+diff --git a/src/PosteRazor.desktop b/src/PosteRazor.desktop
+new file mode 100644
+index 0000000..2a49792
+--- /dev/null
++++ b/src/PosteRazor.desktop
+@@ -0,0 +1,10 @@
++[Desktop Entry]
++Exec=PosteRazor
++Name=PosteRazor
++Name[zh_CN]=PosteRazor
++Icon=posterazor
++StartupNotify=false
++Categories=Accessibility;Qt;
++Comment=The PosteRazor cuts a raster image into pieces which can afterwards be printed out and assembled to a poster.
++Type=Application
++Version=1.0
+\ No newline at end of file
+diff --git a/src/posterazor.pro b/src/posterazor.pro
+index cabd845..863d101 100644
+--- a/src/posterazor.pro
++++ b/src/posterazor.pro
+@@ -66,3 +66,11 @@ contains (DEFINES, FREEIMAGE_LIB) {
+ }
+ 
+ include (posterazor.pri)
++
++target.path =$$PREFIX/bin
++desktop.files =PosteRazor.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = posterazor.png
++
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    The PosteRazor cuts a raster image into pieces which can afterwards be printed out and assembled to a poster.

Log: add software name--posterazor
![posterazor](https://github.com/linuxdeepin/linglong-hub/assets/147463620/fbc0bfe9-9b9a-4c67-81d6-154815e4606a)
