### PR TITLE
build: add openfool

### DIFF
--- a/io.github.openfool/linglong.yaml
+++ b/io.github.openfool/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.openfool
+  name: openfool
+  version: 0.0.9.1
+  kind: app
+  description: |
+    Open source implementation of a Fool (Durak) card game
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/artenax/openfool.git
+  commit: ff48e1241dc79c75ad81d0728af4a6f57deda1e9
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.openfool/patches/0001-install.patch
+++ b/io.github.openfool/patches/0001-install.patch
@@ -1,0 +1,29 @@
+From bbbb49c9889d3b8da150258d962b886ae591e8bc Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Thu, 16 May 2024 12:56:20 +0800
+Subject: [PATCH] install
+
+---
+ OpenFool.pro | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/OpenFool.pro b/OpenFool.pro
+index 0c3ea85..ddfceac 100644
+--- a/OpenFool.pro
++++ b/OpenFool.pro
+@@ -65,3 +65,11 @@ TRANSLATIONS += OpenFool_en.ts OpenFool_ru.ts
+ ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android
+ 
+ RC_ICONS = icons/icon_128_win.ico
++
++target.path = $$PREFIX/bin
++desktop.files = openfool.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = openfool.png
++
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Open source implementation of a Fool (Durak) card game

Log: add software name--openfool
![openfool](https://github.com/linuxdeepin/linglong-hub/assets/147463620/62e1c8d2-42fe-4650-80b0-8c02a7b42ce2)
