### PR TITLE
build: add QComicBook

### DIFF
--- a/io.github.QComicBook/linglong.yaml
+++ b/io.github.QComicBook/linglong.yaml
@@ -1,0 +1,23 @@
+package:
+  id: io.github.QComicBook
+  name: QComicBook
+  version: 0.9.1
+  kind: app
+  description: |
+    Viewer for comic book archives that aims at convenience and simplicity
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: poppler/0.71.0.2
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/stolowski/QComicBook.git
+  commit: d0fc37d6f269a999a24108c5d52026bf539da279
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Viewer for comic book archives that aims at convenience and simplicity

Log: add software name--QComicBook
![QComicBook](https://github.com/linuxdeepin/linglong-hub/assets/147463620/69bdb35b-0d93-4ab7-ba42-564b46d37e71)
