### PR TITLE
build: add quickterminal

### DIFF
--- a/io.github.quickterminal/linglong.yaml
+++ b/io.github.quickterminal/linglong.yaml
@@ -1,0 +1,33 @@
+package:
+  id: io.github.quickterminal
+  name: quickterminal
+  version: 0.0.2
+  kind: app
+  description: |
+    Lightweight terminal emulator
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtermwidget/0.14.1
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/trollixx/quickterminal.git
+  commit: cf7dc467e1d1b7554c672b3970f706564f202384
+  patch: patches/0001-install.patch
+
+
+build:
+  kind: qmake
+  manual:
+    configure: |
+      cp src/icons/application-icon.png src/icons/utilities-terminal.png
+      qmake -makefile  ${conf_args} ${extra_args}
+    build: |
+      make ${jobs}
+    install: |
+      make ${jobs} DESTDIR=${dest_dir} install

--- a/io.github.quickterminal/patches/0001-install.patch
+++ b/io.github.quickterminal/patches/0001-install.patch
@@ -1,0 +1,51 @@
+From 61558c5e93c706bf7c4cd602a30dfa342858c593 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Fri, 17 May 2024 10:58:03 +0800
+Subject: [PATCH] install
+
+---
+ desktop/quickterminal.desktop | 2 +-
+ quickterminal.pro             | 8 +++++---
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/desktop/quickterminal.desktop b/desktop/quickterminal.desktop
+index c5f931d..ebe6be1 100644
+--- a/desktop/quickterminal.desktop
++++ b/desktop/quickterminal.desktop
+@@ -8,7 +8,7 @@ Comment[ru_RU]=Эмулятор терминала
+ Comment[fr]=Terminal
+ 
+ Icon=utilities-terminal
+-Exec=qt
++Exec=QuickTerminal
+ Terminal=false
+ Categories=Qt;System;TerminalEmulator;
+ Actions=Dropdown;
+diff --git a/quickterminal.pro b/quickterminal.pro
+index 0d71dad..2dd10a8 100644
+--- a/quickterminal.pro
++++ b/quickterminal.pro
+@@ -2,7 +2,7 @@ QT += gui gui-private widgets
+ CONFIG += c++11 link_pkgconfig
+ PKGCONFIG += qtermwidget5 x11
+ 
+-TARGET = qt
++TARGET = QuickTerminal
+ 
+ DEFINES += STR_VERSION=\\\"1.0\\\"
+ 
+@@ -29,7 +29,9 @@ unix {
+ 
+     shortcut.path = $$PREFIX/share/applications
+     shortcut.files = desktop/quickterminal.desktop
+-
+-    INSTALLS += target shortcut
++    icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++    icons.files = src/icons/utilities-terminal.png
++ 
++    INSTALLS += target shortcut  icons
+ }
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    Lightweight terminal emulator

Log: add software name--quickterminal
![quickterminal](https://github.com/linuxdeepin/linglong-hub/assets/147463620/070ca34e-1d18-467f-b57c-40b04070a263)
