### PR TITLE
build: add MultiupMaNaGeR

### DIFF
--- a/io.github.MultiupMaNaGeR/linglong.yaml
+++ b/io.github.MultiupMaNaGeR/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.MultiupMaNaGeR
+  name: MultiupMaNaGeR
+  version: 0.4.6.1
+  kind: app
+  description: |
+    Multiup MaNaGeR is a software written in Qt/C++ that can send files to the multiupload website : multiup.org.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/ysard/MultiupMaNaGeR.git
+  commit: b095c87aa328c82cd623ce26b65f2399372eef0c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.MultiupMaNaGeR/patches/0001-install.patch
+++ b/io.github.MultiupMaNaGeR/patches/0001-install.patch
@@ -1,0 +1,45 @@
+From b2c3a636bfbfe8c4df8681ca9a3c20215fd6e126 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 22 May 2024 10:46:33 +0800
+Subject: [PATCH] install
+
+---
+ misc/multiup-manager.desktop | 4 ++--
+ multiupv2.pro                | 8 ++++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/misc/multiup-manager.desktop b/misc/multiup-manager.desktop
+index b15fb10..114aef0 100644
+--- a/misc/multiup-manager.desktop
++++ b/misc/multiup-manager.desktop
+@@ -2,8 +2,8 @@
+ Type=Application
+ Terminal=false
+ Name=Multiup MaNaGeR
+-Exec=/usr/bin/multiup
+-Icon=/usr/share/pixmaps/multiup.png
++Exec=multiup
++Icon=multiup
+ Comment=Upload manager for multiup.org
+ Comment[fr_FR]=Gestionnaire d'upload pour multiup.org
+ Comment[fr]=Gestionnaire d'upload pour multiup.org
+diff --git a/multiupv2.pro b/multiupv2.pro
+index 8e09ecd..92f2a3b 100644
+--- a/multiupv2.pro
++++ b/multiupv2.pro
+@@ -138,3 +138,11 @@ CONFIG += lrelease
+ CONFIG += embed_translations
+ # Default prefix in resources
+ #QM_FILES_RESOURCE_PREFIX=/i18n/
++
++target.path = $$PREFIX/bin
++desktop.files = misc/multiup-manager.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = misc/multiup.png
++
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    Multiup MaNaGeR is a software written in Qt/C++ that can send files to the multiupload website : multiup.org.

Log: add software name--MultiupMaNaGeR
![MultiupMaNaGeR](https://github.com/linuxdeepin/linglong-hub/assets/147463620/efaa2392-55be-4f0e-8749-ce573b9d41b3)
