### PR TITLE
build: add djvu-imager-qt

### DIFF
--- a/io.github.djvu-imager-qt/linglong.yaml
+++ b/io.github.djvu-imager-qt/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.djvu-imager-qt
+  name: djvu-imager-qt
+  version: 2.9.1
+  kind: app
+  description: |
+     It is based on the combination of the background glueing and mask coloring methods.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/trufanov-nok/djvu-imager-qt.git
+  commit: 70913e3caf559210ff0f4e5fbbf60377c5fde426
+  patch: patches/0001-install.patch
+
+build:
+  kind: cmake

--- a/io.github.djvu-imager-qt/patches/0001-install.patch
+++ b/io.github.djvu-imager-qt/patches/0001-install.patch
@@ -1,0 +1,27 @@
+From 88c7bd09e02c87b246762c8c3f497fa1bbc93de5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 22 May 2024 11:05:09 +0800
+Subject: [PATCH] install
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b0718b..9f0be71 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,8 +136,8 @@ target_link_libraries(djvu-imager-qt PRIVATE Qt5::Widgets)
+ 
+ 
+ IF(NOT WIN32 AND NOT APPLE)
+-    INSTALL(FILES res/djvu-imager-qt.png DESTINATION "/usr/share/pixmaps/")
+-    INSTALL(FILES debian/djvu-imager-qt.desktop DESTINATION "/usr/share/applications/")
++    INSTALL(FILES res/djvu-imager-qt.png DESTINATION  share/icons/hicolor/16X16/apps/)
++    INSTALL(FILES debian/djvu-imager-qt.desktop DESTINATION share/applications)
+ ENDIF(NOT WIN32 AND NOT APPLE)
+ 
+ IF(APPLE)
+-- 
+2.33.1
+


### PR DESCRIPTION
     It is based on the combination of the background glueing and mask coloring methods.

Log: add software name--djvu-imager-qt
![djvu-imager-qt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/7d0eacfc-0572-4731-a95d-bdb65b9f1964)
