### PR TITLE
build: add esptool-gui

### DIFF
--- a/io.github.esptool-gui/linglong.yaml
+++ b/io.github.esptool-gui/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.esptool-gui
+  name: esptool-gui
+  version: 0.0.2
+  kind: app
+  description: |
+    A GUI for ESP8266 flash tool esptool-ck with basic features, geared towards being a production flashing tool.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/Rodmg/esptool-gui.git
+  commit: a8ad8526f95ba7908a95a6ad90ed8768654a691c
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.esptool-gui/patches/0001-install.patch
+++ b/io.github.esptool-gui/patches/0001-install.patch
@@ -1,0 +1,41 @@
+From 894182d65e251d7fb3c2f0ce760e9b786483f9c2 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 22 May 2024 11:57:47 +0800
+Subject: [PATCH] install
+
+---
+ esptool-gui.desktop | 2 +-
+ esptool-gui.pro     | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/esptool-gui.desktop b/esptool-gui.desktop
+index 61a5ecf..ec3d74f 100644
+--- a/esptool-gui.desktop
++++ b/esptool-gui.desktop
+@@ -2,5 +2,5 @@
+ Type=Application
+ Name=esptool-gui
+ Exec=esptool-gui
+-Icon=esptool-gui
++Icon=esptool-gui-screenshot
+ Categories=Development;
+diff --git a/esptool-gui.pro b/esptool-gui.pro
+index 82b4321..fdba787 100644
+--- a/esptool-gui.pro
++++ b/esptool-gui.pro
+@@ -18,3 +18,11 @@ SOURCES += main.cpp\
+ HEADERS  += mainwindow.h
+ 
+ FORMS    += mainwindow.ui
++
++target.path = $$PREFIX/bin
++desktop.files = esptool-gui.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = esptool-gui-screenshot.png
++
++INSTALLS += target desktop icons
+\ No newline at end of file
+-- 
+2.33.1
+


### PR DESCRIPTION
    A GUI for ESP8266 flash tool esptool-ck with basic features, geared towards being a production flashing tool.

Log: add software name--esptool-gui
![esptool-gui](https://github.com/linuxdeepin/linglong-hub/assets/147463620/27e050e9-0625-440a-9650-eeb6ea070f98)
