### PR TITLE
build: add small-scope-qt

### DIFF
--- a/io.github.small-scope-qt/linglong.yaml
+++ b/io.github.small-scope-qt/linglong.yaml
@@ -1,0 +1,24 @@
+package:
+  id: io.github.small-scope-qt
+  name: small-scope-qt
+  version: 1.0.0.1
+  kind: app
+  description: |
+    GUI for small-scope arduino oscilloscope
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+depends:
+  - id: qtserialport/5.15.7
+    type: runtime
+
+source:
+  kind: git
+  url: https://github.com/marvin-sinister/small-scope-qt.git
+  commit: 9ab33af10292a4c98b38557e30c2b117ce654e3a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.small-scope-qt/patches/0001-install.patch
+++ b/io.github.small-scope-qt/patches/0001-install.patch
@@ -1,0 +1,46 @@
+From 8c2eee492f3ca3e188192bebbf981e95753b05d5 Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Wed, 22 May 2024 13:30:37 +0800
+Subject: [PATCH] install
+
+---
+ icons/small-scope-qt.desktop | 9 +++++++++
+ small-scope-qt.pro           | 8 ++++++++
+ 2 files changed, 17 insertions(+)
+ create mode 100644 icons/small-scope-qt.desktop
+
+diff --git a/icons/small-scope-qt.desktop b/icons/small-scope-qt.desktop
+new file mode 100644
+index 0000000..24112e7
+--- /dev/null
++++ b/icons/small-scope-qt.desktop
+@@ -0,0 +1,9 @@
++[Desktop Entry]
++Exec=small-scope-qt
++Name=small-scope-qt
++Name[zh_CN]=small-scope-qt
++Icon=oscilloscope-icon
++Comment=GUI for small-scope arduino oscilloscope
++Type=Application
++GenericName=small-scope-qt
++Version=1.0
+\ No newline at end of file
+diff --git a/small-scope-qt.pro b/small-scope-qt.pro
+index 4fbfef6..4dc36c1 100644
+--- a/small-scope-qt.pro
++++ b/small-scope-qt.pro
+@@ -43,3 +43,11 @@ HEADERS  += settingsdialog.h \
+ FORMS    += settingsdialog.ui \
+     mainwindow.ui \
+     about.ui
++
++target.path = $$PREFIX/bin
++desktop.files = icons/small-scope-qt.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = icons/oscilloscope-icon.png
++
++INSTALLS += target desktop icons
+-- 
+2.33.1
+


### PR DESCRIPTION
    GUI for small-scope arduino oscilloscope

Log: add software name--small-scope-qt
![small-scope-qt](https://github.com/linuxdeepin/linglong-hub/assets/147463620/57fba441-322b-43e5-a028-726a434c5de4)
