### PR TITLE
build: add EmuDiscer

### DIFF
--- a/io.github.EmuDiscer/linglong.yaml
+++ b/io.github.EmuDiscer/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.EmuDiscer
+  name: EmuDiscer
+  version: 1.1.0
+  kind: app
+  description: |
+     EmuDiscer recognizes which system the game is made for, and lauches the right emulator.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/LMauricius/EmuDiscer.git
+  commit: 02af5b8b0d07caa7d4e1b969f9962a5951ca075a
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.EmuDiscer/patches/0001-install.patch
+++ b/io.github.EmuDiscer/patches/0001-install.patch
@@ -1,0 +1,59 @@
+From 9aedec24aa5b3fda1268b3280660ca0c264b322a Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 25 May 2024 16:31:30 +0800
+Subject: [PATCH] install
+
+---
+ EmuDiscer.pro                | 11 ++++++++++-
+ LMauricius.EmuDiscer.desktop | 14 +++++++-------
+ 2 files changed, 17 insertions(+), 8 deletions(-)
+
+diff --git a/EmuDiscer.pro b/EmuDiscer.pro
+index ebc31c9..a9b693e 100644
+--- a/EmuDiscer.pro
++++ b/EmuDiscer.pro
+@@ -59,10 +59,19 @@ DEFINES += EMUDISCER_APP_VERSION=\\\"$$VERSION\\\"
+ 
+ # Default rules for deployment.
+ qnx: target.path = /tmp/$${TARGET}/bin
+-else: unix:!android: target.path = /opt/$${TARGET}/bin
++else: unix:!android: #target.path = /opt/$${TARGET}/bin
+ !isEmpty(target.path): INSTALLS += target
+ 
+ RESOURCES += \
+     resources.qrc
+ 
+ DISTFILES +=
++
++
++target.path = $$PREFIX/bin
++desktop.files = LMauricius.EmuDiscer.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/scalable/apps
++icons.files = EmuDiscer.svg
++
++INSTALLS += target desktop icons
+diff --git a/LMauricius.EmuDiscer.desktop b/LMauricius.EmuDiscer.desktop
+index 2c9f46e..e41d1ca 100644
+--- a/LMauricius.EmuDiscer.desktop
++++ b/LMauricius.EmuDiscer.desktop
+@@ -1,9 +1,9 @@
+ [Desktop Entry]
+-Categories = Game;
+-Comment = A program for running emulators when a disc is inserted.
+-Exec = EmuDiscer --open-settings
+-Icon = EmuDiscer
+-Name = EmuDiscer
+-Terminal = false
+-Type = Application
++Categories=Game;
++Comment=A program for running emulators when a disc is inserted.
++Exec=EmuDiscer
++Icon=EmuDiscer
++Name=EmuDiscer
++Terminal=false
++Type=Application
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
     EmuDiscer recognizes which system the game is made for, and lauches the right emulator.

Log: add software name--EmuDiscer
![EmuDiscer](https://github.com/linuxdeepin/linglong-hub/assets/147463620/9d97239d-d090-4daf-9d43-a3962a7f402b)
