### PR TITLE
build: add opulus

### DIFF
--- a/io.github.opulus/linglong.yaml
+++ b/io.github.opulus/linglong.yaml
@@ -1,0 +1,19 @@
+package:
+  id: io.github.opulus
+  name: opulus
+  version: 0.9.6
+  kind: app
+  description: |
+    Simple Petri net editor and simulator
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/zettdaymond/opulus.git
+  commit: ed04c26eb2fad755f22c4ad8267cdab2cbe5812d
+
+build:
+  kind: cmake


### PR DESCRIPTION
    Simple Petri net editor and simulator

Log: add software name--opulus
![opulus](https://github.com/linuxdeepin/linglong-hub/assets/147463620/902dd0e9-d5e6-446f-ae3a-487cae87c7a6)
