### PR TITLE
build: add faustworks

### DIFF
--- a/io.github.faustworks/linglong.yaml
+++ b/io.github.faustworks/linglong.yaml
@@ -1,0 +1,20 @@
+package:
+  id: io.github.faustworks
+  name: faustworks
+  version: 0.4.0.1
+  kind: app
+  description: |
+    FaustWorks is an IDE (Integrated Development Environment) for the Faust dsp programming language
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/grame-cncm/faustworks.git
+  commit: af03cba9c166715334c7e3c5263b6505ef16df26
+  patch: patches/0001-install.patch
+
+build:
+  kind: qmake

--- a/io.github.faustworks/patches/0001-install.patch
+++ b/io.github.faustworks/patches/0001-install.patch
@@ -1,0 +1,31 @@
+From cea32e49df922eb50339c4f4b5d879a1b117b07b Mon Sep 17 00:00:00 2001
+From: wjyrich <1071633242@qq.com>
+Date: Sat, 25 May 2024 19:09:25 +0800
+Subject: [PATCH] install
+
+---
+ FaustWorks.pro | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/FaustWorks.pro b/FaustWorks.pro
+index 36f4178..47b0b35 100644
+--- a/FaustWorks.pro
++++ b/FaustWorks.pro
+@@ -60,6 +60,14 @@ QMAKE_EXTRA_TARGETS += i18n_qm
+ 
+ PRE_TARGETDEPS += i18n_qm
+ 
++target.path = $$PREFIX/bin
++desktop.files = faustworks.desktop
++desktop.path = $$PREFIX/share/applications/
++icons.path = $$PREFIX/share/icons/hicolor/16X16/apps/
++icons.files = Resources/faustworks.png
++
++INSTALLS += target desktop icons
++
+ 
+ 
+ 
+-- 
+2.33.1
+


### PR DESCRIPTION
    FaustWorks is an IDE (Integrated Development Environment) for the Faust dsp programming language.

Log: add software name--faustworks
![faustworks](https://github.com/linuxdeepin/linglong-hub/assets/147463620/2251e004-09db-4cce-af6c-bf413b5c6e53)
