### PR TITLE
build: add app Tasker

### DIFF
--- a/io.github.Tasker/linglong.yaml
+++ b/io.github.Tasker/linglong.yaml
@@ -1,0 +1,25 @@
+package:
+  id: io.github.Tasker
+  name: Tasker
+  version: 0.2.0
+  kind: app
+  description: |
+    A commitment tracker desktop app that tracks the progress of your tasks with mouse, keyboard and audio hooks.
+
+runtime:
+  id: org.deepin.Runtime
+  version: 23.0.0
+
+source:
+  kind: git
+  url: https://github.com/thebigG/Tasker.git
+  commit: 0678598ecc0aa3ac471b2504ba9bd640ea4417ac
+  patch:
+    - patches/fix_install.patch
+
+variables:
+  extra_args: |
+    -DUSE_XKB_FILE=OFF
+
+build:
+  kind: cmake

--- a/io.github.Tasker/patches/fix_install.patch
+++ b/io.github.Tasker/patches/fix_install.patch
@@ -1,0 +1,14 @@
+diff --git a/Tasker/CMakeLists.txt b/Tasker/CMakeLists.txt
+index cbfe8f5..70517c3 100644
+--- a/Tasker/CMakeLists.txt
++++ b/Tasker/CMakeLists.txt
+@@ -103,5 +103,7 @@ else(WIN32)
+ endif()
+ 
+ install(TARGETS Tasker
+-    DESTINATION ${CMAKE_INSTALL_PREFIX}
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+     )
++install(FILES Tasker.desktop DESTINATION share/applications/)
++install(FILES clock-256.png DESTINATION share/icons/hicolor/16x16/)
+


### PR DESCRIPTION
A commitment tracker desktop app that tracks the progress of your tasks with mouse, keyboard and audio hooks.

![image](https://github.com/linuxdeepin/linglong-hub/assets/20265354/4a3f0387-6b9f-4068-8dd1-bf84e9661831)

Logs: add app name--Tasker